### PR TITLE
Add routines to compute stochastic eigenvectors of Markov transition matrices

### DIFF
--- a/doc/source/matrices.txt
+++ b/doc/source/matrices.txt
@@ -506,6 +506,26 @@ Examples::
     [0.0]
 
 
+Stochastic matrices
+...................
+
+The routine ``stoch_eig`` returns the stochastic eigenvector of an
+irreducible stochastic matrix *P*, i.e., the stochastic vector `x` with
+`x P = x` (a stochastic matrix, or Markov transition matrix, is a real
+square matrix whose entries are nonnegative and rows sum to one).
+Internally, the routine passes the input to the ``gth_solve`` routine.
+
+The routine ``gth_solve`` solves for a (normalized) nontrivial solution
+to `x A = 0` for an irreducible transition rate matrix *A* (a transition
+rate matrix is a real square matrix whose off-diagonal entries are
+nonnegative and rows sum to zero), by using the Grassmann-Taksar-Heyman
+(GTH) algorithm, a numerically stable variant of Gaussian
+elimination.
+
+.. autofunction :: mpmath.stoch_eig
+.. autofunction :: mpmath.gth_solve
+
+
 Interval and double-precision matrices
 --------------------------------------
 

--- a/mpmath/__init__.py
+++ b/mpmath/__init__.py
@@ -165,6 +165,8 @@ svd_r = mp.svd_r
 svd_c = mp.svd_c
 svd = mp.svd
 gauss_quadrature = mp.gauss_quadrature
+stoch_eig = mp.stoch_eig
+gth_solve = mp.gth_solve
 
 expm = mp.expm
 sqrtm = mp.sqrtm
@@ -458,4 +460,3 @@ def doctests(filter=[]):
 
 if __name__ == '__main__':
     doctests()
-

--- a/mpmath/matrices/__init__.py
+++ b/mpmath/matrices/__init__.py
@@ -1,2 +1,3 @@
 from . import eigen           # to set methods
 from . import eigen_symmetric # to set methods
+from . import eigen_markov    # to set methods

--- a/mpmath/matrices/eigen_markov.py
+++ b/mpmath/matrices/eigen_markov.py
@@ -64,22 +64,22 @@ def stoch_eig(ctx, P, overwrite=False):
     equals one. Internally, the routine passes the input to the
     ``gth_solve`` routine.
 
-    Parameters
-    ----------
+    **Parameters**
+
     P : matrix of shape (n, n)
         Stochastic matrix.
     overwrite : bool, optional(default=False)
         If True, allows modification of P which may improve performance;
         if False, P is not modified.
 
-    Returns
-    -------
+    **Returns**
+
     matrix of shape (1, n)
         Stochastic eigenvalue (stationary distribution) of P, i.e., the
         solution to x P = x, normalized so that its 1-norm equals one.
 
-    Examples
-    --------
+    **Examples**
+
     >>> import mpmath as mp
     >>> from eigen_markov import stoch_eig
     >>> P = mp.matrix([[0.9, 0.075, 0.025], [0.15, 0.8, 0.05], [0.25, 0.25, 0.5]])
@@ -110,22 +110,22 @@ def gth_solve(ctx, A, overwrite=False):
     variant of Gaussian elimination. The solution is normalized so that
     its 1-norm equals one.
 
-    Parameters
-    ----------
+    **Parameters**
+
     A : matrix of shape (n, n)
         Transition rate matrix.
     overwrite : bool, optional(default=False)
         If True, allows modification of A which may improve performance;
         if False, A is not modified.
 
-    Returns
-    -------
+    **Returns**
+
     matrix of shape (1, n)
         Non-zero solution to x A = 0, normalized so that its 1-norm
         equals one.
 
-    Examples
-    --------
+    **Examples**
+
     >>> import mpmath as mp
     >>> from eigen_markov import gth_solve
     >>> A = mp.matrix([[-0.1, 0.075, 0.025], [0.15, -0.2, 0.05], [0.25, 0.25, -0.5]])

--- a/mpmath/matrices/eigen_markov.py
+++ b/mpmath/matrices/eigen_markov.py
@@ -1,0 +1,173 @@
+"""
+Filename: eigen_markov.py
+
+Author: Daisuke Oyama
+
+This file contains some routines specialized for stochastic (Markov) matrices.
+
+stoch_eig : returns the stochastic eigenvector (stationary distribution)
+    of an irreducible stochastic matrix P, i.e., the stochastic vector x
+    with x P = x
+gth_solve : returns the (normalized) nontrivial solution to x A = 0 for
+    an irreducible transition rate matrix A
+
+
+Stochastic matrices
+...................
+
+The routine ``stoch_eig`` returns the stochastic eigenvector of an
+irreducible stochastic matrix *P*, i.e., the stochastic vector `x` with
+`x P = x` (a stochastic matrix, or Markov transition matrix, is a real
+square matrix whose entries are nonnegative and rows sum to one).
+Internally, the routine passes the input to the ``gth_solve`` routine.
+
+The routine ``gth_solve`` solves for a (normalized) nontrivial solution
+to `x A = 0` for an irreducible transition rate matrix *A* (a transition
+rate matrix is a real square matrix whose off-diagonal entries are
+nonnegative and rows sum to zero), by using the Grassmann-Taksar-Heyman
+(GTH) algorithm [1]_, a numerically stable variant of Gaussian
+elimination.
+
+
+Notes
+-----
+For stochastic matrices, see en.wikipedia.org/wiki/Stochastic_matrix
+For transition rate matrices, see en.wikipedia.org/wiki/Transition_rate_matrix
+For irreducible matrices, see
+en.wikipedia.org/wiki/Perron-Frobenius_theorem#Classification_of_matrices
+
+If the input matrix is not irreducible, ``stoch_eig`` (``gth_solve``)
+returns the solution corresponding to the irreducible class of indices
+that contains the first recurrent index.
+
+For the GTH algorithm, see the excellent lecture notes [2]_.
+
+References
+----------
+.. [1] W. K. Grassmann, M. I. Taksar and D. P. Heyman, "Regenerative
+   Analysis and Steady State Distributions for Markov Chains,"
+   Operations Research (1985), 1107-1116.
+.. [2] W. J. Stewart, "Performance Modelling and Markov Chains,"
+   www.sti.uniurb.it/events/sfm07pe/slides/Stewart_1.pdf
+
+"""
+from ..libmp.backend import xrange
+from .eigen import defun
+
+
+@defun
+def stoch_eig(ctx, P, overwrite=False):
+    r"""
+    This routine returns the stochastic eigenvector (stationary
+    probability distribution vector) of an irreducible stochastic matrix
+    *P*, i.e., the solution to `x P = x`, normalized so that its 1-norm
+    equals one. Internally, the routine passes the input to the
+    ``gth_solve`` routine.
+
+    Parameters
+    ----------
+    P : matrix of shape (n, n)
+        Stochastic matrix.
+    overwrite : bool, optional(default=False)
+        If True, allows modification of P which may improve performance;
+        if False, P is not modified.
+
+    Returns
+    -------
+    matrix of shape (1, n)
+        Stochastic eigenvalue (stationary distribution) of P, i.e., the
+        solution to x P = x, normalized so that its 1-norm equals one.
+
+    Examples
+    --------
+    >>> import mpmath as mp
+    >>> from eigen_markov import stoch_eig
+    >>> P = mp.matrix([[0.9, 0.075, 0.025], [0.15, 0.8, 0.05], [0.25, 0.25, 0.5]])
+    >>> x = mp.mp.stoch_eig(P)
+    >>> print x
+    [0.625  0.3125  0.0625]
+    >>> print x * P
+    [0.625  0.3125  0.0625]
+
+    """
+    # In fact, stoch_eig, which for the user is a routine to solve
+    # x P = x, or x (P - I) = 0, is just another name of the function
+    # gth_solve, which solves x A = 0, where the GTH algorithm,
+    # the algorithm used there, does not use the actual values of
+    # the diagonals of A, under the assumption that
+    # A_{ii} = \sum_{j \neq i} A_{ij}, and therefore,
+    # gth_solve(P-I) = gth_solve(P), so that it is irrelevant whether to
+    # pass P or P - I to gth_solve.
+    return ctx.gth_solve(P, overwrite=overwrite)
+
+
+@defun
+def gth_solve(ctx, A, overwrite=False):
+    r"""
+    This routine computes a nontrivial solution of a linear equation
+    system of the form `x A = 0`, where *A* is an irreducible transition
+    rate matrix, by using the Grassmann-Taksar-Heyman (GTH) algorithm, a
+    variant of Gaussian elimination. The solution is normalized so that
+    its 1-norm equals one.
+
+    Parameters
+    ----------
+    A : matrix of shape (n, n)
+        Transition rate matrix.
+    overwrite : bool, optional(default=False)
+        If True, allows modification of A which may improve performance;
+        if False, A is not modified.
+
+    Returns
+    -------
+    matrix of shape (1, n)
+        Non-zero solution to x A = 0, normalized so that its 1-norm
+        equals one.
+
+    Examples
+    --------
+    >>> import mpmath as mp
+    >>> from eigen_markov import gth_solve
+    >>> A = mp.matrix([[-0.1, 0.075, 0.025], [0.15, -0.2, 0.05], [0.25, 0.25, -0.5]])
+    >>> x = mp.mp.gth_solve(A)
+    >>> print x
+    [0.625  0.3125  0.0625]
+    >>> print mp.chop(x*A)
+    [0.0  0.0  0.0]
+
+    """
+    if not isinstance(A, ctx.matrix):
+        A = ctx.matrix(A)
+    elif not overwrite:
+        A = A.copy()
+
+    n, m = A.rows, A.cols
+
+    if n != m:
+        raise ValueError('matrix must be square')
+
+    x = ctx.zeros(1, n)
+
+    # === Reduction === #
+    for j in xrange(n-1):
+        scale = ctx.fsum(A[j, j+1:n])
+        if scale <= 0:
+            # Only consider the leading principal minor of size j+1,
+            # which is irreducible
+            n = j+1
+            break
+        A[j+1:n, j] /= scale
+
+        for i in xrange(j+1, n):
+            for k in xrange(j+1, n):
+                A[k, i] += A[j, i] * A[k, j]
+
+    # === Backward substitution === #
+    x[n-1] = 1
+    for i in xrange(n-2, -1, -1):
+        x[i] = ctx.fsum((x[j] * A[j, i] for j in xrange(i+1, n)))
+
+    # === Normalization === #
+    x /= ctx.fsum(x)
+
+    return x

--- a/mpmath/tests/test_eigen_markov.py
+++ b/mpmath/tests/test_eigen_markov.py
@@ -204,9 +204,9 @@ def test_gth_solve_fp():
 
 
 def test_stoch_eig_iv():
-    P = mp.iv.matrix([[0.9 , 0.075, 0.025],
-                      [0.15, 0.8  , 0.05 ],
-                      [0.25, 0.25 , 0.5  ]])
+    P = mp.iv.matrix([['0.9' , '0.075', '0.025'],
+                      ['0.15', '0.8'  , '0.05' ],
+                      ['0.25', '0.25' , '0.5'  ]])
     x_expected = mp.matrix([[0.625, 0.3125, 0.0625]])
     x_iv = mp.iv.stoch_eig(P)
     for value, interval in zip(x_expected, x_iv):
@@ -214,9 +214,9 @@ def test_stoch_eig_iv():
 
 
 def test_gth_solve_iv():
-    P = mp.iv.matrix([[-0.1, 0.075, 0.025],
-                      [0.15, -0.2 , 0.05 ],
-                      [0.25, 0.25 , -0.5 ]])
+    P = mp.iv.matrix([['-0.1', '0.075', '0.025'],
+                      ['0.15', '-0.2' , '0.05' ],
+                      ['0.25', '0.25' , '-0.5' ]])
     x_expected = mp.matrix([[0.625, 0.3125, 0.0625]])
     x_iv = mp.iv.gth_solve(P)
     for value, interval in zip(x_expected, x_iv):

--- a/mpmath/tests/test_eigen_markov.py
+++ b/mpmath/tests/test_eigen_markov.py
@@ -1,0 +1,223 @@
+from __future__ import division, print_function
+
+import mpmath as mp
+
+VERBOSE = 0
+
+
+# Generate test cases
+def KMR_Markov_matrix_sequential(N, p, epsilon):
+    """
+    Generate a Markov matrix arising from a certain game-theoretic model
+
+    Parameters
+    ----------
+    N : int
+
+    p : float
+        Between 0 and 1
+
+    epsilon : float
+        Between 0 and 1
+
+    Returns
+    -------
+    P : matrix of shape (N+1, N+1)
+
+    """
+    P = mp.zeros(N+1, N+1)
+    P[0, 0], P[0, 1] = 1 - epsilon * (1/2), epsilon * (1/2)
+    for n in range(1, N):
+        P[n, n-1] = \
+            (n/N) * (epsilon * (1/2) +
+                     (1 - epsilon) * (((n-1)/(N-1) < p) + ((n-1)/(N-1) == p) * (1/2))
+                     )
+        P[n, n+1] = \
+            ((N-n)/N) * (epsilon * (1/2) +
+                         (1 - epsilon) * ((n/(N-1) > p) + (n/(N-1) == p) * (1/2))
+                         )
+        P[n, n] = 1 - P[n, n-1] - P[n, n+1]
+    P[N, N-1], P[N, N] = epsilon * (1/2), 1 - epsilon * (1/2)
+    return P
+
+
+# Stochastic matrix instances
+Ps = []
+
+Ps.append(
+    mp.matrix([[0.9 , 0.075, 0.025],
+               [0.15, 0.8  , 0.05 ],
+               [0.25, 0.25 , 0.5  ]])
+)
+Ps.append(KMR_Markov_matrix_sequential(N=3, p=1./3, epsilon=1e-14))
+Ps.append(KMR_Markov_matrix_sequential(N=27, p=1./3, epsilon=1e-2))
+
+# Transition rate matrix instances
+As = [P.copy() for P in Ps]
+for A in As:
+    for i in range(A.rows):
+        A[i, i] = -mp.fsum((A[i, j] for j in range(A.cols) if j != i))
+
+
+def run_stoch_eig(P, verbose=0):
+    """
+    stoch_eig returns a stochastic vector x such that x P = x
+    for an irreducible stochstic matrix P.
+    """
+    if verbose > 1:
+        print("original matrix (stoch_eig):\n", P)
+
+    x = mp.stoch_eig(P)
+
+    if verbose > 1:
+        print("x\n", x)
+
+    eps = mp.exp(0.8 * mp.log(mp.eps))  # From test_eigen.py
+
+    # x is a left eigenvector of P with eigenvalue unity
+    err0 = mp.norm(x*P-x, p=1)
+    if verbose > 0:
+        print("|xP - x| (stoch_eig):", err0)
+    assert err0 < eps
+
+    # x is a nonnegative vector
+    if verbose > 0:
+        print("min(x) (stoch_eig):", min(x))
+    assert min(x) >= 0 - eps
+
+    # 1-norm of x is one
+    err1 = mp.fabs(mp.norm(x, p=1) - 1)
+    if verbose > 0:
+        print("||x| - 1| (stoch_eig):", err1)
+    assert err1 < eps
+
+
+def run_gth_solve(A, verbose=0):
+    """
+    gth_solve returns a stochastic vector x such that x A = 0
+    for an irreducible transition rate matrix A.
+    """
+    if verbose > 1:
+        print("original matrix (gth_solve):\n", A)
+
+    x = mp.gth_solve(A)
+
+    if verbose > 1:
+        print("x\n", x)
+
+    eps = mp.exp(0.8 * mp.log(mp.eps))  # test_eigen.py
+
+    # x is a solution to x A = 0
+    err0 = mp.norm(x*A, p=1)
+    if verbose > 0:
+        print("|xA| (gth_solve):", err0)
+    assert err0 < eps
+
+    # x is a nonnegative vector
+    if verbose > 0:
+        print("min(x) (gth_solve):", min(x))
+    assert min(x) >= 0 - eps
+
+    # 1-norm of x is one
+    err1 = mp.fabs(mp.norm(x, p=1) - 1)
+    if verbose > 0:
+        print("||x| - 1| (gth_solve):", err1)
+    assert err1 < eps
+
+
+#######################
+
+
+def test_stoch_eig_fixed_matrix():
+    for P in Ps:
+        run_stoch_eig(P, verbose=VERBOSE)
+
+
+def test_gth_solve_fixed_matrix():
+    for A in As:
+        run_gth_solve(A, verbose=VERBOSE)
+
+
+def test_stoch_eig_randmatrix():
+    N = 5
+
+    for j in range(10):
+        P = mp.randmatrix(N, N)
+
+        for i in range(N):
+            P[i, :] /= mp.fsum(P[i, :])
+
+        run_stoch_eig(P, verbose=VERBOSE)
+
+
+def test_gth_solve_randmatrix():
+    N = 5
+
+    for j in range(10):
+        A = mp.randmatrix(N, N)
+
+        for i in range(N):
+            A[i, :] /= mp.fsum(A[i, :])
+            A[i, i] = -mp.fsum((A[i, j] for j in range(N) if j != i))
+
+        run_gth_solve(A, verbose=VERBOSE)
+
+
+def test_stoch_eig_high_prec():
+    n = 1e-100
+    with mp.workdps(100):
+        P = mp.matrix([[1-3*(mp.exp(n)-1), 3*(mp.exp(n)-1)],
+                       [mp.exp(n)-1      , 1-(mp.exp(n)-1)]])
+
+    run_stoch_eig(P, verbose=VERBOSE)
+
+
+def test_gth_solve_high_prec():
+    n = 1e-100
+    with mp.workdps(100):
+        P = mp.matrix([[-3*(mp.exp(n)-1), 3*(mp.exp(n)-1)],
+                       [mp.exp(n)-1     , -(mp.exp(n)-1) ]])
+
+    run_gth_solve(P, verbose=VERBOSE)
+
+
+def test_stoch_eig_fp():
+    P = mp.fp.matrix([[0.9 , 0.075, 0.025],
+                      [0.15, 0.8  , 0.05 ],
+                      [0.25, 0.25 , 0.5  ]])
+    x_expected = mp.fp.matrix([[0.625, 0.3125, 0.0625]])
+    x = mp.fp.stoch_eig(P)
+    eps = mp.exp(0.8 * mp.log(mp.eps))  # test_eigen.py
+    err0 = mp.norm(x-x_expected, p=1)
+    assert err0 < eps
+
+
+def test_gth_solve_fp():
+    P = mp.fp.matrix([[-0.1, 0.075, 0.025],
+                      [0.15, -0.2 , 0.05 ],
+                      [0.25, 0.25 , -0.5 ]])
+    x_expected = mp.fp.matrix([[0.625, 0.3125, 0.0625]])
+    x = mp.fp.gth_solve(P)
+    eps = mp.exp(0.8 * mp.log(mp.eps))  # test_eigen.py
+    err0 = mp.norm(x-x_expected, p=1)
+    assert err0 < eps
+
+
+def test_stoch_eig_iv():
+    P = mp.iv.matrix([[0.9 , 0.075, 0.025],
+                      [0.15, 0.8  , 0.05 ],
+                      [0.25, 0.25 , 0.5  ]])
+    x_expected = mp.matrix([[0.625, 0.3125, 0.0625]])
+    x_iv = mp.iv.stoch_eig(P)
+    for value, interval in zip(x_expected, x_iv):
+        assert value in interval
+
+
+def test_gth_solve_iv():
+    P = mp.iv.matrix([[-0.1, 0.075, 0.025],
+                      [0.15, -0.2 , 0.05 ],
+                      [0.25, 0.25 , -0.5 ]])
+    x_expected = mp.matrix([[0.625, 0.3125, 0.0625]])
+    x_iv = mp.iv.gth_solve(P)
+    for value, interval in zip(x_expected, x_iv):
+        assert value in interval


### PR DESCRIPTION
Hello,
this pull request is to add routines to compute the stationary distribution vector of a Markov matrix, implementing an algorithm called the "GTH-algorithm", a numerically stable variant of Gaussian elimination. They should be useful in particular when the subdominant (second largest) eigenvalue of the Markov matrix is close to 1.

The routines, which are specialized in computing the eigenvector with eigenvalue 1 for irreducible Markov matrices, are much faster than the general purpose routine `eig`.

I also included some test code and added documents that describe the routines.
I hope you find this useful.
