### PR TITLE
Fix latex sphinx's configuration (for pdf output)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -125,7 +125,7 @@ latex_documents = [(master_doc, 'main.tex', 'mpmath documentation',
                     r'Fredrik Johansson \and mpmath contributors', 'manual')]
 
 # Additional stuff for the LaTeX preamble.
-#latex_preamble = ''
+latex_preamble = r'\usepackage{amsfonts}'
 
 # Documents to append as an appendix to all manuals.
 #latex_appendices = []

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -121,8 +121,8 @@ htmlhelp_basename = 'mpmathdoc'
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
-latex_documents = [master_doc, 'main.tex', 'mpmath documentation',
-                   'Fredrik Johansson \and mpmath contributors', 'manual']
+latex_documents = [(master_doc, 'main.tex', 'mpmath documentation',
+                    r'Fredrik Johansson \and mpmath contributors', 'manual')]
 
 # Additional stuff for the LaTeX preamble.
 #latex_preamble = ''


### PR DESCRIPTION
Now pdf generation should work on RTD too.  You can reproduce their pdf build with:
```
cd doc/source/
sphinx-build -b latex -d _build/doctrees . _build/latex
cd _build/latex/
pdflatex -interaction=nonstopmode main.tex 
```

See [latest build](http://mpmath.readthedocs.org/en/latest/) and [pdf output](https://readthedocs.org/projects/mpmath/downloads/pdf/latest/).