### PR TITLE
Use classic sphinx theme (for RTD too)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -75,10 +75,8 @@ pygments_style = 'sphinx'
 # Options for HTML output
 # -----------------------
 
-# The style sheet to use for HTML and HTML Help pages. A file of that name
-# must exist either in Sphinx' static/ path, or in one of the custom paths
-# given in html_static_path.
-html_style = 'default.css'
+# The "theme" that the HTML output should use.
+html_theme = 'classic'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
For newer sphinx versions (at least in case of 1.3.1, see sphinx-doc/sphinx#1835), referenced in the conf.py default.css doesn't exists.  Proposed workaround is just using sphinx_theme option.

Also, this PR make mpmath's documentation on RTD look exactly as http://mpmath.org/doc/current/ (except for small pop-up box in the right corner.  If you are ok with that, I'll provide a patch for README.rst (replace http://mpmath.org/doc with http://mpmath.rtfd.org).

New look:
http://mpmath1.readthedocs.org/en/sphinx-std-theme/