### PR TITLE
Minor edit in functions/bessel.py

### DIFF
--- a/mpmath/functions/bessel.py
+++ b/mpmath/functions/bessel.py
@@ -123,7 +123,7 @@ def bessely(ctx, n, z, derivative=0, **kwargs):
             # ~ log(z/2)
             return -ctx.inf + (n+z)
         if ctx.im(n):
-            return nan * (n+z)
+            return ctx.nan * (n+z)
         r = ctx.re(n)
         q = n+0.5
         if ctx.isint(q):


### PR DESCRIPTION
While experimenting with cythonizing all of mpmath, this file produced an error arising from the edited line. Of four instances of `nan` in this file, this one is treated differently.