### PR TITLE
lbmpi - mpi_mul by zero

### DIFF
--- a/mpmath/libmp/libmpi.py
+++ b/mpmath/libmp/libmpi.py
@@ -136,14 +136,10 @@ def mpi_mul(s, t, prec=0):
     tas = mpf_sign(ta)
     tbs = mpf_sign(tb)
     if sas == sbs == 0:
-        # Should maybe be undefined
-        if ta == fninf or tb == finf:
-            return fninf, finf
+        # for any x in R, 0*x=0
         return fzero, fzero
     if tas == tbs == 0:
-        # Should maybe be undefined
-        if sa == fninf or sb == finf:
-            return fninf, finf
+        # for any x in R, x*0=0
         return fzero, fzero
     if sas >= 0:
         # positive * positive


### PR DESCRIPTION
My understanding of the documentation is that iv.mpf represent closed intervals of R:
"The iv.mpf type represents a closed interval [a,b]; that is, the set {x:a≤x≤b}"
In particular if b is 'inf', iv.mpf(a,'inf') represents the set {x:a≤x}.
Then [0,0] \* [a,inf] = {0 \* x : a≤x} = {0}.
Contrary to floats where a lot of small numbers collapse to zero, iv.mpf([0,0]) is the singleton 0.
Thus, mpi_mul should return [0,0] if one of its arguments is [0,0].
This would be consistent with the fact that mpi_mul([0, 1], [1, 'inf']) and mpi_mul([-1, 0], [1, 'inf']) currently returns [0, 'inf'] and [-'inf', 0] respectively, and not [-'inf', 'inf'].
