### PR TITLE
Use %s instead of %g in findroot error

### DIFF
--- a/mpmath/calculus/optimization.py
+++ b/mpmath/calculus/optimization.py
@@ -970,7 +970,7 @@ def findroot(ctx, f, x0, solver=Secant, tol=None, verbose=False, verify=True, **
             xl = x
         if verify and norm(f(*xl))**2 > tol: # TODO: better condition?
             raise ValueError('Could not find root within given tolerance. '
-                             '(%g > %g)\n'
+                             '(%s > %s)\n'
                              'Try another starting point or tweak arguments.'
                              % (norm(f(*xl))**2, tol))
         return x

--- a/mpmath/calculus/optimization.py
+++ b/mpmath/calculus/optimization.py
@@ -887,7 +887,7 @@ def findroot(ctx, f, x0, solver=Secant, tol=None, verbose=False, verify=True, **
         >>> findroot(lambda x: x**2, (-1, .5), solver='anderson')
         Traceback (most recent call last):
           ...
-        ValueError: Could not find root within given tolerance. (1 > 2.1684e-19)
+        ValueError: Could not find root within given tolerance. (1.0 > 2.16840434497100886801e-19)
         Try another starting point or tweak arguments.
 
     """


### PR DESCRIPTION
This fixes incorrect cutoff for tolerances that don't fit in a Python float.

This causes the error message to be longer, especially when the precision is
set high. Perhaps there is a better way to only print a few digits without
using %g.

Fixes an issue mentioned in #339.