### PR TITLE
[wip] Set eliminate=False per default in hyper()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,3 +176,8 @@ mpmath@googlegroups.com
 
 You can also report bugs and send patches to the mpmath issue tracker,
 https://github.com/fredrik-johansson/mpmath/issues
+
+This project adheres to
+[No Code of Conduct]((https://github.com/domgetter/NCoC).
+Contributions will be judged by their technical merit.
+Nothing else matters.

--- a/mpmath/function_docs.py
+++ b/mpmath/function_docs.py
@@ -2816,9 +2816,9 @@ series terminates before the division by zero occurs)::
     >>> hyper([1,1,1,-1],[-2,5],1)
     1.1
 
-With the keyword argument ``eliminate=True``, function degree reduced
+With the keyword argument ``eliminate=True``, the function degree is reduced
 first by cancellation of common parameters.  For nonpositive parameters
-that may lead to the different function definition::
+that may lead to a different function definition::
 
     >>> hyper([-1, 1],[-1],2)
     3.0

--- a/mpmath/function_docs.py
+++ b/mpmath/function_docs.py
@@ -2816,6 +2816,15 @@ series terminates before the division by zero occurs)::
     >>> hyper([1,1,1,-1],[-2,5],1)
     1.1
 
+With the keyword argument ``eliminate=True``, function degree reduced
+first by cancellation of common parameters.  For nonpositive parameters
+that may lead to the different function definition::
+
+    >>> hyper([-1, 1],[-1],2)
+    3.0
+    >>> hyper([-1, 1],[-1],2,eliminate=True)
+    -1.0
+
 Except for polynomial cases, the radius of convergence `R` of the hypergeometric
 series is either `R = \infty` (if `p \le q`), `R = 1` (if `p = q+1`), or
 `R = 0` (if `p > q+1`).

--- a/mpmath/functions/hypergeometric.py
+++ b/mpmath/functions/hypergeometric.py
@@ -202,7 +202,7 @@ def hyper(ctx, a_s, b_s, z, **kwargs):
     a_s = [ctx._convert_param(a) for a in a_s]
     b_s = [ctx._convert_param(b) for b in b_s]
     # Reduce degree by eliminating common parameters
-    if kwargs.get('eliminate', True):
+    if kwargs.get('eliminate', False):
         i = 0
         while i < q and a_s:
             b = b_s[i]

--- a/mpmath/tests/test_functions2.py
+++ b/mpmath/tests/test_functions2.py
@@ -152,6 +152,10 @@ def test_hyper_misc():
     assert hyper([(3,4),2+j,1],[1,5,j/3],mpf(1)/5+j/8).ae(v)
     mp.dps = 15
 
+    # defaults for eliminate
+    assert hyper([-1,1],[-1],2) == 3
+    assert hyper([-1,1],[-1],2,eliminate=True) == -1
+
 def test_elliptic_integrals():
     mp.dps = 15
     assert ellipk(0).ae(pi/2)
@@ -519,8 +523,8 @@ def test_hyper_2f1():
 def test_hyper_2f1_hard():
     mp.dps = 15
     # Singular cases
-    assert hyp2f1(2,-1,-1,3).ae(0.25)
-    assert hyp2f1(2,-2,-2,3).ae(0.25)
+    assert hyp2f1(2,-1,-1,3,eliminate=True).ae(0.25)
+    assert hyp2f1(2,-2,-2,3,eliminate=True).ae(0.25)
     assert hyp2f1(2,-1,-1,3,eliminate=False) == 7
     assert hyp2f1(2,-2,-2,3,eliminate=False) == 34
     assert hyp2f1(2,-2,-3,3) == 14

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@
 # W292 - no newline at end of file
 # W391 - blank line at end of file
 select = E101,W191,W291,W293,E111,E112,E113,W292,W391
-[pytest]
+[tool:pytest]
 addopts = --doctest-modules
           --ignore=setup.py
           --doctest-glob='*.txt'


### PR DESCRIPTION
Not sure how common cancellation is to affect performance badly.  Hence, here is a simplest solution for #349.

Except one test, nothing seems to be affected in your test suite.  But please note, that moderate amount of docstrings - not tested.

Also readme update about Code of Conduct.
