### PR TITLE
allow for numpy arrays in fdot()

### DIFF
--- a/mpmath/ctx_mp_python.py
+++ b/mpmath/ctx_mp_python.py
@@ -914,7 +914,7 @@ class PythonMPContext(object):
             mpc(real='3.5', imag='-5.0')
 
         """
-        if B:
+        if B is not None:
             A = zip(A, B)
         prec, rnd = ctx._prec_rounding
         real = []


### PR DESCRIPTION
Up until now, the code
```python
from mpmath import mp
import numpy

x = numpy.random.rand(10)
y = numpy.random.rand(10)

mp.fdot(x, y)
```
fails with
```
    if B:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all(
```
Numpy arrays cannot simply be used as conditionals.

The simple fix is to replace the conditional.