### PR TITLE
Fix PEP-479 compatibility (python 3.7)

### DIFF
--- a/mpmath/functions/qfunctions.py
+++ b/mpmath/functions/qfunctions.py
@@ -123,7 +123,7 @@ def qp(ctx, a, q=None, n=None, **kwargs):
             r *= q
             k += 1
             if k >= n:
-                raise StopIteration
+                return
             if k > maxterms:
                 raise ctx.NoConvergence
     return ctx.mul_accurately(factors)


### PR DESCRIPTION
'raise StopIteration' is turned into a RuntimeError under python3.7
when the generator function stack is exited because of it (and causes
a warning under python3.6). It is equivalent to plain 'return', which
works under both python2.x and python3.x.