### PR TITLE
Fix several invalid escapes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 script:
   # Guard against invalid escapes in strings, like '\s'. If this fails, a
   # string or docstring somewhere needs to be a raw string.
-  - if [ "$TRAVIS_PYTHON_VERSION" == "3.6" ];
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.6" ]; then
         python -We:invalid -m compileall -f mpmath;
     fi
   - pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7
   - "pypy"
 install:
   - pip install pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
   - "pypy"
 install:
   - pip install pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 script:
   # Guard against invalid escapes in strings, like '\s'. If this fails, a
   # string or docstring somewhere needs to be a raw string.
-  - if [ "$TRAVIS_PYTHON_VERSION" = "3.6" ];
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.6" ];
         python -We:invalid -m compileall -f mpmath
     fi
   - pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   # Guard against invalid escapes in strings, like '\s'. If this fails, a
   # string or docstring somewhere needs to be a raw string.
   - if [ "$TRAVIS_PYTHON_VERSION" == "3.6" ];
-        python -We:invalid -m compileall -f mpmath
+        python -We:invalid -m compileall -f mpmath;
     fi
   - pep8
   - py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ python:
 install:
   - pip install pep8
 script:
+  # Guard against invalid escapes in strings, like '\s'. If this fails, a
+  # string or docstring somewhere needs to be a raw string.
+  - if [ "$TRAVIS_PYTHON_VERSION" = "3.6" ];
+        python -We:invalid -m compileall -f mpmath
+    fi
   - pep8
   - py.test
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.3
   - 3.4
   - 3.5
+  - 3.6
   - "pypy"
 install:
   - pip install pep8

--- a/mpmath/calculus/extrapolation.py
+++ b/mpmath/calculus/extrapolation.py
@@ -727,7 +727,7 @@ defun(levin)
 
 class cohen_alt_class:
     # cohen_alt: Copyright 2013 Timo Hartmann (thartmann15 at gmail.com)
-    """
+    r"""
     This interface implements the convergence acceleration of alternating series
     as described in H. Cohen, F.R. Villegas, D. Zagier - "Convergence Acceleration
     of Alternating Series". This series transformation works only well if the

--- a/mpmath/calculus/quadrature.py
+++ b/mpmath/calculus/quadrature.py
@@ -383,7 +383,7 @@ class TanhSinh(QuadratureRule):
 
 
 class GaussLegendre(QuadratureRule):
-    """
+    r"""
     This class implements Gauss-Legendre quadrature, which is
     exceptionally efficient for polynomials and polynomial-like (i.e.
     very smooth) integrands.
@@ -407,7 +407,7 @@ class GaussLegendre(QuadratureRule):
     """
 
     def calc_nodes(self, degree, prec, verbose=False):
-        """
+        r"""
         Calculates the abscissas and weights for Gauss-Legendre
         quadrature of degree of given degree (actually `3 \cdot 2^m`).
         """

--- a/mpmath/ctx_mp.py
+++ b/mpmath/ctx_mp.py
@@ -455,7 +455,7 @@ class MPContext(BaseMPContext, StandardBaseContext):
         return PrecisionManager(ctx, None, lambda d: n, normalize_output)
 
     def autoprec(ctx, f, maxprec=None, catch=(), verbose=False):
-        """
+        r"""
         Return a wrapped copy of *f* that repeatedly evaluates *f*
         with increasing precision until the result converges to the
         full precision used at the point of the call.

--- a/mpmath/identification.py
+++ b/mpmath/identification.py
@@ -532,7 +532,7 @@ transforms = [
 
 def identify(ctx, x, constants=[], tol=None, maxcoeff=1000, full=False,
     verbose=False):
-    """
+    r"""
     Given a real number `x`, ``identify(x)`` attempts to find an exact
     formula for `x`. This formula is returned as a string. If no match
     is found, ``None`` is returned. With ``full=True``, a list of

--- a/mpmath/libmp/gammazeta.py
+++ b/mpmath/libmp/gammazeta.py
@@ -356,7 +356,7 @@ mpf_twinprime = def_mpf_constant(twinprime_fixed)
 MAX_BERNOULLI_CACHE = 3000
 
 
-"""
+r"""
 Small Bernoulli numbers and factorials are used in numerous summations,
 so it is critical for speed that sequential computation is fast and that
 values are cached up to a fairly high threshold.
@@ -800,7 +800,7 @@ def mpc_gamma_old(x, prec, rounding=round_fast, p1=1):
 #                                                                       #
 #-----------------------------------------------------------------------#
 
-"""
+r"""
 For all polygamma (psi) functions, we use the Euler-Maclaurin summation
 formula. It looks slightly different in the m = 0 and m > 0 cases.
 
@@ -1065,7 +1065,7 @@ def mpc_psi(m, z, prec, rnd=round_fast):
 #                                                                       #
 #-----------------------------------------------------------------------#
 
-"""
+r"""
 We use zeta(s) = eta(s) / (1 - 2**(1-s)) and Borwein's approximation
 
                   n-1

--- a/mpmath/libmp/libelefun.py
+++ b/mpmath/libmp/libelefun.py
@@ -175,7 +175,7 @@ def ln10_fixed(prec):
     return machin([(46, 31), (34, 49), (20, 161)], prec, True)
 
 
-"""
+r"""
 For computation of pi, we use the Chudnovsky series:
 
              oo


### PR DESCRIPTION
Future versions of Python will make invalid escapes in strings like `'\s'` a syntax error if the string isn't a raw string. This makes several docstrings in mpmath with backslashes raw. I didn't check but potentially some of these even had valid escapes, meaning things like `\t` or `\n` which would just produce the corresponding whitespace character in the parsed string. 

These cause issues for upstream SymPy, as we have our tests set to fail if there are invalid escapes. See https://github.com/sympy/sympy/pull/15094. 

I am also setting up testing of 3.6 and 3.7 in Travis, and testing of invalid escapes there so they won't reappear. 