### PR TITLE
Return passed in function in defun* decorators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.7-dev
   - pypy

--- a/README.rst
+++ b/README.rst
@@ -107,8 +107,8 @@ Release history:
 1. Download & installation
 --------------------------
 
-Mpmath requires Python 2.7 or 3.4 (or later versions). It has been tested
-with CPython 2.7, 3.4 through 3.7 and for PyPy.
+Mpmath requires Python 2.7 or 3.5 (or later versions). It has been tested
+with CPython 2.7, 3.5 through 3.7 and for PyPy.
 
 The latest release of mpmath can be downloaded from the mpmath
 website and from https://github.com/fredrik-johansson/mpmath/releases

--- a/mpmath/function_docs.py
+++ b/mpmath/function_docs.py
@@ -9770,8 +9770,8 @@ on the unit sphere::
     >>> Y1 = lambda t,p: fp.spherharm(l1,m1,t,p)
     >>> Y2 = lambda t,p: fp.conj(fp.spherharm(l2,m2,t,p))
     >>> l1 = l2 = 3; m1 = m2 = 2
-    >>> print(fp.quad(lambda t,p: Y1(t,p)*Y2(t,p)*dS(t,p), *sphere))
-    (1+0j)
+    >>> fp.chop(fp.quad(lambda t,p: Y1(t,p)*Y2(t,p)*dS(t,p), *sphere))
+    1.0000000000000007
     >>> m2 = 1    # m1 != m2
     >>> print(fp.chop(fp.quad(lambda t,p: Y1(t,p)*Y2(t,p)*dS(t,p), *sphere)))
     0.0
@@ -10011,7 +10011,7 @@ Pass ``exact=True`` to obtain exact values of Stirling numbers as integers::
 
     >>> stirling1(42, 5)
     -2.864498971768501633736628e+50
-    >>> print stirling1(42, 5, exact=True)
+    >>> print(stirling1(42, 5, exact=True))
     -286449897176850163373662803014001546235808317440000
 
 """
@@ -10045,7 +10045,7 @@ Pass ``exact=True`` to obtain exact values of Stirling numbers as integers::
 
     >>> stirling2(52, 10)
     2.641822121003543906807485e+45
-    >>> print stirling2(52, 10, exact=True)
+    >>> print(stirling2(52, 10, exact=True))
     2641822121003543906807485307053638921722527655
 
 

--- a/mpmath/functions/functions.py
+++ b/mpmath/functions/functions.py
@@ -80,12 +80,15 @@ class SpecialFunctions(object):
 
 def defun_wrapped(f):
     SpecialFunctions.defined_functions[f.__name__] = f, True
+    return f
 
 def defun(f):
     SpecialFunctions.defined_functions[f.__name__] = f, False
+    return f
 
 def defun_static(f):
     setattr(SpecialFunctions, f.__name__, f)
+    return f
 
 @defun_wrapped
 def cot(ctx, z): return ctx.one / ctx.tan(z)

--- a/mpmath/functions/zeta.py
+++ b/mpmath/functions/zeta.py
@@ -938,8 +938,8 @@ def secondzeta(ctx, s, a = 0.015, **kwargs):
         0.023104993115419
         >>> xi = lambda s: 0.5*s*(s-1)*pi**(-0.5*s)*gamma(0.5*s)*zeta(s)
         >>> Xi = lambda t: xi(0.5+t*j)
-        >>> -0.5*diff(Xi,0,n=2)/Xi(0)
-        (0.023104993115419 + 0.0j)
+        >>> chop(-0.5*diff(Xi,0,n=2)/Xi(0))
+        0.023104993115419
 
     We may ask for an approximate error value::
 

--- a/mpmath/functions/zeta.py
+++ b/mpmath/functions/zeta.py
@@ -1029,12 +1029,12 @@ def secondzeta(ctx, s, a = 0.015, **kwargs):
         err = r1+r2+r4
         t = t1-t2+t3-t4
         if kwargs.get("verbose"):
-            print_('main term =', t1)
-            print_('    computed using', gt, 'zeros of zeta')
-            print_('prime term =', t2)
-            print_('    computed using', pt, 'values of the von Mangoldt function')
-            print_('exponential term =', t3)
-            print_('singular term =', t4)
+            print('main term =', t1)
+            print('    computed using', gt, 'zeros of zeta')
+            print('prime term =', t2)
+            print('    computed using', pt, 'values of the von Mangoldt function')
+            print('exponential term =', t3)
+            print('singular term =', t4)
     finally:
         ctx.prec = prec
     if kwargs.get("error"):

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ develop = %(tests)s
 select = E101,W191,W291,W293,E111,E112,E113,W292,W391
 exclude = .eggs,.git
 [tool:pytest]
+doctest_optionflags = IGNORE_EXCEPTION_DETAIL
 addopts = --doctest-modules
           --ignore=setup.py
           --doctest-glob='*.txt'

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers = License :: OSI Approved :: BSD License
               Programming Language :: Python :: 2
               Programming Language :: Python :: 2.7
               Programming Language :: Python :: 3
-              Programming Language :: Python :: 3.4
               Programming Language :: Python :: 3.5
               Programming Language :: Python :: 3.6
               Programming Language :: Python :: 3.7


### PR DESCRIPTION
This turn on more doctests, e.g.:

```
$ py.test mpmath/functions/qfunctions.py
============================= test session starts ==============================
platform linux -- Python 3.7.1, pytest-4.2.0, py-1.7.0, pluggy-0.8.1
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/sk/src/mpmath/.hypothesis/examples')
rootdir: /home/sk/src/mpmath, inifile: setup.cfg
plugins: xdist-1.26.1, timeout-1.3.3, forked-1.0.1, cov-2.6.1, hypothesis-4.4.3
collected 4 items

mpmath/functions/qfunctions.py ....                                      [100%]

=========================== 4 passed in 0.49 seconds ===========================
```