### PR TITLE
Improve slicing and add matrix multiply

### DIFF
--- a/mpmath/matrices/matrices.py
+++ b/mpmath/matrices/matrices.py
@@ -437,18 +437,18 @@ class _matrix(object):
         
         '''
         if isinstance(key_1d,int):
-            return xrange(key_1d,key_1d+1)
+            return xrange(key_1d%depth,key_1d%depth+1)
         elif isinstance(key_1d,slice):
             return xrange(*key_1d.indices(depth))
         elif isinstance(key_1d,list):
             if isinstance(key_1d[0],bool):
                 if len(key_1d) != depth:
                     raise IndexError('boolean mask does not match dimension size')
-                return [i for i,x in enumerate(key_1d) if x] # return list so that we can take length late
+                return [k for k,x in enumerate(key_1d) if x] # return list so that we can take length late
             elif isinstance(key_1d[0],int):
                 if min(key_1d)<0 or max(key_1d) >= depth:
                     raise IndexError('index is out of bounds')
-                return key_1d
+                return [k%depth for k in key_1d]
             else:
                 raise IndexError('index array must be int or bool')
         else:

--- a/mpmath/matrices/matrices.py
+++ b/mpmath/matrices/matrices.py
@@ -437,7 +437,7 @@ class _matrix(object):
         
         '''
         if isinstance(key_1d,int):
-            return xrange(key_1d%depth,key_1d%depth+1)
+            return xrange(key_1d%depth,key_1d%depth00+1)
         elif isinstance(key_1d,slice):
             return xrange(*key_1d.indices(depth))
         elif isinstance(key_1d,list):
@@ -448,7 +448,7 @@ class _matrix(object):
             elif isinstance(key_1d[0],int):
                 if min(key_1d)<0 or max(key_1d) >= depth:
                     raise IndexError('index is out of bounds')
-                return [k%depth for k in key_1d]
+                return key_1d
             else:
                 raise IndexError('index array must be int or bool')
         else:
@@ -461,7 +461,6 @@ class _matrix(object):
         - slices
         - integer array
         - boolean mask
-        
            
         Notes
         -----

--- a/mpmath/matrices/matrices.py
+++ b/mpmath/matrices/matrices.py
@@ -437,7 +437,7 @@ class _matrix(object):
         
         '''
         if isinstance(key_1d,int):
-            return xrange(key_1d%depth,key_1d%depth00+1)
+            return xrange(key_1d%depth,key_1d%depth+1)
         elif isinstance(key_1d,slice):
             return xrange(*key_1d.indices(depth))
         elif isinstance(key_1d,list):

--- a/mpmath/matrices/matrices.py
+++ b/mpmath/matrices/matrices.py
@@ -470,11 +470,11 @@ class _matrix(object):
         # parse key
         if isinstance(key,(int,slice,list)):
             # if the matrix is a row vector take only 0th row
-            if self.rows == 1:
+            if self.__rows == 1:
                 i = 0
                 j = key
             # if the matrix is a column vector take only 0th column
-            if self.cols == 1:
+            elif self.__cols == 1:
                 i = key
                 j = 0
             # otherwise assume we take all columns
@@ -482,8 +482,11 @@ class _matrix(object):
                 i = key
                 j = slice(None,None,None)
         elif isinstance(key,tuple):
-            assert len(key) == 2, 'mpmath matrix class only allows two dimensional matrices'
+            if len(key) != 2:
+                raise IndexError('mpmath matrix class only allows two dimensional matrices')
             i,j = key
+        else:
+            raise IndexError('could not understand given key')
 
         # return scalar if both dimensions are integers
         if isinstance(i,int) and isinstance(j,int):
@@ -522,16 +525,24 @@ class _matrix(object):
         # parse key
         if isinstance(key,(int,slice,list)):
             # if the matrix is a row vector pull element
-            if self.rows == 1:
+            if self.__rows == 1:
                 i = 0
                 j = key
+            # if the matrix is a column vector take only 0th column
+            elif self.__cols == 1:
+                i = key
+                j = 0
+            # otherwise assume we take all columns
             else:
                 i = key
                 j = slice(None,None,None)
         elif isinstance(key,tuple):
-            assert len(key) == 2, 'mpmath matrix class only allows two dimensional matrices'
+            if len(key) != 2:
+                raise IndexError('mpmath matrix class only allows two dimensional matrices')
             i,j = key
-    
+        else:
+            raise IndexError('could not understand given key')
+        
         i_indices = self.__get_indices(i,self.__rows)
         j_indices = self.__get_indices(j,self.__cols)
 
@@ -591,6 +602,7 @@ class _matrix(object):
         if isinstance(other, self.ctx.matrix):
             # dot multiplication  TODO: use Strassen's method?
             if self.__cols != other.__rows:
+                print(self.__rows,self.__cols,other.__rows,other.__cols)
                 raise ValueError('dimensions not compatible for multiplication')
             new = self.ctx.matrix(self.__rows, other.__cols)
             # loop over nonzero entries of self


### PR DESCRIPTION
The general theme of this pull request is adding some functionality to make the syntax more similar to numpy. Hopefully this will make it easier to port code from numpy to mpmath. 

I don't believe that any of the changes implemented here will change any of the behaviour of existing code. That is, all operations arithmetic operations will be performed in exactly the same order. 

- Add `__matmul__` method with multiply which takes advantage of sparsity
  - Note that since the order of some of the scalar multiplications is changed the exact output will vary slightly from the original `__mul__` method but the norms of the matrices should not differ by more the machine precision times the product of the norms of the matrices.

- Update `__getitem__` and `__setitem__` methods to allow indexing with boolean and integer lists
  - I have simplified the syntax for the case handling 
  - Note that using a slice which is out of bounds will behave like slicing a python list (i.e. it gets mapped in bounds). So just as `[1,2,3,4][2:10]` returns  `[3,4]`, `mp.matrix([1,2,3,4])[2:10]` will return a matrix with the elements 3 and 4. This means one test from the matrix tests will fail since it wants this to raise an error.
  - if the `key` provided is not a tuple, then these functions check if you are working with a vector, in which case it assumes you want to slice along the non-trivial axis. Otherwise it will assume the rows should be sliced and take all columns

 - add `.shape` property

Note: `test_quad.py` fails, but it failed before I made any changes (as far as I can tell).