### PR TITLE
Enable sage backend by default only if SAGE_ROOT is set

### DIFF
--- a/mpmath/libmp/backend.py
+++ b/mpmath/libmp/backend.py
@@ -79,7 +79,8 @@ if 'MPMATH_NOGMPY' not in os.environ:
     except:
         pass
 
-if 'MPMATH_NOSAGE' not in os.environ:
+if ('MPMATH_NOSAGE' not in os.environ and 'SAGE_ROOT' in os.environ or
+        'MPMATH_SAGE' in os.environ):
     try:
         import sage.all
         import sage.libs.mpmath.utils as _sage_utils


### PR DESCRIPTION
It's possible to install the Sage system as a normal Python package, as
e.g. in Fedora/Debian. In this case, presence of `sage.all` is not an
indicator whether the user is running Sage, and checking for 'SAGE_ROOT'
is more reliable.

There are some behavior differences in mpmath with the Sage backend,
(e.g. `mpmath.ker(0, 0)` is `0` on sage but `inf` on gmpy), but a larger reason
for this change could be that the Sage backend probably makes sense mostly
when using Sage.