### PR TITLE
Prevent division by zero

### DIFF
--- a/mpmath/calculus/extrapolation.py
+++ b/mpmath/calculus/extrapolation.py
@@ -253,7 +253,7 @@ def shanks(ctx, seq, table=None, randomized=False):
                 b = row[j-1] - table[i-1][j-1]
             if not b:
                 if randomized:
-                    b = rnd.getrandbits(10)*eps
+                    b = (1 + rnd.getrandbits(10))*eps
                 elif i & 1:
                     return table[:-1]
                 else:


### PR DESCRIPTION
Problem: `rnd.getrandbits` can result in 0, so that `b` could equal to 0.

This fix makes it that b is a pseudorandom number close, but not equal,
to zero.