### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/demo/manydigits.py
+++ b/demo/manydigits.py
@@ -8,6 +8,7 @@ Run with:
     python manydigits.py
 
 """
+from __future__ import print_function
 
 from mpmath import *
 from mpmath.libmp import to_fixed, bin_to_radix
@@ -24,81 +25,81 @@ def pr(x):
     s = str(d).zfill(dps)[-dps:]
     return s[:dps//2] + "\n" + s[dps//2:]
 
-print """
+print("""
 This script prints answers to a selection of the "Many Digits"
 competition problems: http://www.cs.ru.nl/~milad/manydigits/problems.php
 
 The output for each problem is the first 100 digits after the
 decimal point in the result.
-"""
+""")
 
-print "C01: sin(tan(cos(1)))"
-print pr(sin(tan(cos(1))))
-print
+print("C01: sin(tan(cos(1)))")
+print(pr(sin(tan(cos(1)))))
+print()
 
-print "C02: sqrt(e/pi)"
-print pr(sqrt(e/pi))
-print
+print("C02: sqrt(e/pi)")
+print(pr(sqrt(e/pi)))
+print()
 
-print "C03: sin((e+1)^3)"
-print pr(sin((e+1)**3))
-print
+print("C03: sin((e+1)^3)")
+print(pr(sin((e+1)**3)))
+print()
 
-print "C04: exp(pi*sqrt(2011))"
+print("C04: exp(pi*sqrt(2011))")
 mp.dps += 65
-print pr(exp(pi*sqrt(2011)))
+print(pr(exp(pi*sqrt(2011))))
 mp.dps -= 65
-print
+print()
 
-print "C05: exp(exp(exp(1/2)))"
-print pr(exp(exp(exp(0.5))))
-print
+print("C05: exp(exp(exp(1/2)))")
+print(pr(exp(exp(exp(0.5)))))
+print()
 
-print "C06: arctanh(1-arctanh(1-arctanh(1-arctanh(1/pi))))"
-print pr(atanh(1-atanh(1-atanh(1-atanh(1/pi)))))
-print
+print("C06: arctanh(1-arctanh(1-arctanh(1-arctanh(1/pi))))")
+print(pr(atanh(1-atanh(1-atanh(1-atanh(1/pi))))))
+print()
 
-print "C07: pi^1000"
+print("C07: pi^1000")
 mp.dps += 505
-print pr(pi**1000)
+print(pr(pi**1000))
 mp.dps -= 505
-print
+print()
 
-print "C08: sin(6^(6^6))"
-print pr(sin(6**(6**6)))
-print
+print("C08: sin(6^(6^6))")
+print(pr(sin(6**(6**6))))
+print()
 
-print "C09: sin(10*arctan(tanh(pi*(2011^(1/2))/3)))"
+print("C09: sin(10*arctan(tanh(pi*(2011^(1/2))/3)))")
 mp.dps += 150
-print pr(sin(10*atan(tanh(pi*sqrt(2011)/3))))
+print(pr(sin(10*atan(tanh(pi*sqrt(2011)/3)))))
 mp.dps -= 150
-print
+print()
 
-print "C10: (7+2^(1/5)-5*(8^(1/5)))^(1/3) + 4^(1/5)-2^(1/5)"
+print("C10: (7+2^(1/5)-5*(8^(1/5)))^(1/3) + 4^(1/5)-2^(1/5)")
 a = mpf(1)/5
-print pr(((7 + 2**a - 5*(8**a))**(mpf(1)/3) + 4**a - 2**a))
-print
+print(pr(((7 + 2**a - 5*(8**a))**(mpf(1)/3) + 4**a - 2**a)))
+print()
 
-print "C11: tan(2^(1/2))+arctanh(sin(1))"
-print pr((tan(sqrt(2)) + atanh(sin(1))))
-print
+print("C11: tan(2^(1/2))+arctanh(sin(1))")
+print(pr((tan(sqrt(2)) + atanh(sin(1)))))
+print()
 
-print "C12: arcsin(1/e^2) + arcsinh(e^2)"
-print pr(asin(1/exp(2)) + asinh(exp(2)))
-print
+print("C12: arcsin(1/e^2) + arcsinh(e^2)")
+print(pr(asin(1/exp(2)) + asinh(exp(2))))
+print()
 
-print "C17: S= -4*Zeta(2) - 2*Zeta(3) + 4*Zeta(2)*Zeta(3) + 2*Zeta(5)"
-print pr(-4*zeta(2) - 2*zeta(3) + 4*zeta(2)*zeta(3) + 2*zeta(5))
-print
+print("C17: S= -4*Zeta(2) - 2*Zeta(3) + 4*Zeta(2)*Zeta(3) + 2*Zeta(5)")
+print(pr(-4*zeta(2) - 2*zeta(3) + 4*zeta(2)*zeta(3) + 2*zeta(5)))
+print()
 
-print "C18: Catalan G = Sum{i=0}{\infty}(-1)^i/(2i+1)^2"
-print pr(catalan)
-print
+print("C18: Catalan G = Sum{i=0}{\infty}(-1)^i/(2i+1)^2")
+print(pr(catalan))
+print()
 
-print "C21: Equation exp(cos(x)) = x"
-print pr(findroot(lambda x: exp(cos(x))-x, 1))
-print
+print("C21: Equation exp(cos(x)) = x")
+print(pr(findroot(lambda x: exp(cos(x))-x, 1)))
+print()
 
-print "C22: J = integral(sin(sin(sin(x)))), x=0..1"
-print pr(quadts(lambda x: sin(sin(sin(x))), [0, 1]))
-print
+print("C22: J = integral(sin(sin(sin(x)))), x=0..1")
+print(pr(quadts(lambda x: sin(sin(sin(x))), [0, 1])))
+print()

--- a/demo/pidigits.py
+++ b/demo/pidigits.py
@@ -4,6 +4,7 @@ Calculate digits of pi. This module can be run interactively with
     python pidigits.py
 
 """
+from __future__ import print_function
 __docformat__ = 'plaintext'
 
 import sys
@@ -18,10 +19,10 @@ def display_fraction(digits, skip=0, colwidth=10, columns=5):
     for linecount in range((len(digits)-skip) // (colwidth * columns)):
         line = digits[skip+linecount*perline:skip+(linecount+1)*perline]
         for i in range(columns):
-            print line[i*colwidth : (i+1)*colwidth],
-        print ":", (linecount+1)*perline
+            print(line[i*colwidth : (i+1)*colwidth], end=' ')
+        print(":", (linecount+1)*perline)
         if (linecount+1) % 10 == 0:
-            print
+            print()
         printed += colwidth*columns
     rem = (len(digits)-skip) % (colwidth * columns)
     if rem:
@@ -30,7 +31,7 @@ def display_fraction(digits, skip=0, colwidth=10, columns=5):
         for i in range(columns):
             s += buf[:colwidth].ljust(colwidth+1, " ")
             buf = buf[colwidth:]
-        print s + ":", printed + colwidth*columns
+        print(s + ":", printed + colwidth*columns)
 
 def calculateit(base, n, tofile):
     intpart = numeral(3, base)
@@ -40,33 +41,33 @@ def calculateit(base, n, tofile):
 
     prec = int(n*math.log(base,2))+10
 
-    print "Step 1 of 2: calculating binary value..."
+    print("Step 1 of 2: calculating binary value...")
     t = clock()
     a = pi_fixed(prec, verbose=True, verbose_base=base)
     step1_time = clock() - t
 
-    print "Step 2 of 2: converting to specified base..."
+    print("Step 2 of 2: converting to specified base...")
     t = clock()
     d = bin_to_radix(a, prec, base, n)
     d = numeral(d, base, n)
     step2_time = clock() - t
 
-    print "\nWriting output...\n"
+    print("\nWriting output...\n")
 
     if tofile:
         out_ = sys.stdout
         sys.stdout = tofile
-    print "%i base-%i digits of pi:\n" % (n, base)
-    print intpart, ".\n"
+    print("%i base-%i digits of pi:\n" % (n, base))
+    print(intpart, ".\n")
 
     display_fraction(d, skip, colwidth=10, columns=5)
     if tofile:
         sys.stdout = out_
-    print "\nFinished in %f seconds (%f calc, %f convert)" % \
-        ((step1_time + step2_time), step1_time, step2_time)
+    print("\nFinished in %f seconds (%f calc, %f convert)" % \
+        ((step1_time + step2_time), step1_time, step2_time))
 
 def interactive():
-    print "Compute digits of pi with mpmath\n"
+    print("Compute digits of pi with mpmath\n")
     base = input("Which base? (2-36, 10 for decimal) \n> ")
     digits = input("How many digits? (enter a big number, say, 10000)\n> ")
     tofile = raw_input("Output to file? (enter a filename, or just press " \

--- a/demo/plotting.py
+++ b/demo/plotting.py
@@ -1,17 +1,18 @@
 """
 Function plotting demo.
 """
+from __future__ import print_function
 
 from mpmath import *
 
 def main():
-    print """
+    print("""
     Simple function plotting. You can enter one or several
     formulas, in ordinary Python syntax and using the mpmath
     function library. The variable is 'x'. So for example
     the input "sin(x/2)" (without quotation marks) defines
     a valid function.
-    """
+    """)
     functions = []
     for i in xrange(10):
         if i == 0:
@@ -19,18 +20,18 @@ def main():
         else:
             s = raw_input('Enter another function (optional): ')
         if not s:
-            print
+            print()
             break
         f = eval("lambda x: " + s)
         functions.append(f)
-        print "Added f(x) = " + s
-        print
+        print("Added f(x) = " + s)
+        print()
     xlim = raw_input('Enter xmin, xmax (optional): ')
     if xlim:
         xlim = eval(xlim)
     else:
         xlim = [-5, 5]
-    print "Plotting..."
+    print("Plotting...")
     plot(functions, xlim=xlim)
 
 main()

--- a/demo/taylor.py
+++ b/demo/taylor.py
@@ -6,24 +6,25 @@ This module can be run interactively with
     python taylor.py
 
 """
+from __future__ import print_function
 
 from mpmath import *
 
 def taylor(x, n):
-    print "-"*75
+    print("-"*75)
     t = x = mpi(x)
     s = 1
-    print "adding 1"
-    print s, "\n"
+    print("adding 1")
+    print(s, "\n")
     s += t
-    print "adding x"
-    print s, "\n"
+    print("adding x")
+    print(s, "\n")
     for k in range(2, n+1):
         t = (t * x) / k
         s += t
-        print "adding x^%i / %i! ~= %s" % (k, k, t.mid)
-        print s, "\n"
-    print "-"*75
+        print("adding x^%i / %i! ~= %s" % (k, k, t.mid))
+        print(s, "\n")
+    print("-"*75)
     return s
 
 # Note: this should really be computed using interval arithmetic too!
@@ -41,32 +42,32 @@ def exponential(x, n):
     t = taylor(x, n)
     r = remainder(x, n)
     expx = exp(x)
-    print "Correct value of exp(x):    ", expx
-    print
-    print "Computed interval:          "
-    print t
-    print
-    print "Computed value (midpoint):  ", t.mid
-    print
-    print "Estimated rounding error:   ", t.delta
-    print "Estimated truncation error: ", r
-    print "Estimated total error:      ", t.delta + r
-    print "Actual error                ", abs(expx - t.mid)
-    print
+    print("Correct value of exp(x):    ", expx)
+    print()
+    print("Computed interval:          ")
+    print(t)
+    print()
+    print("Computed value (midpoint):  ", t.mid)
+    print()
+    print("Estimated rounding error:   ", t.delta)
+    print("Estimated truncation error: ", r)
+    print("Estimated total error:      ", t.delta + r)
+    print("Actual error                ", abs(expx - t.mid))
+    print()
     u = t + mpi(-r, r)
-    print "Interval with est. truncation error added:"
-    print u
-    print
-    print "Correct value contained in computed interval:", t.a <= expx <= t.b
-    print "When accounting for truncation error:", u.a <= expx <= u.b
+    print("Interval with est. truncation error added:")
+    print(u)
+    print()
+    print("Correct value contained in computed interval:", t.a <= expx <= t.b)
+    print("When accounting for truncation error:", u.a <= expx <= u.b)
 
 if __name__ == "__main__":
-    print "Interval arithmetic demo"
-    print
-    print "This script sums the Taylor series for exp(x) using interval arithmetic,"
-    print "and then compares the numerical errors due to rounding and truncation."
-    print
+    print("Interval arithmetic demo")
+    print()
+    print("This script sums the Taylor series for exp(x) using interval arithmetic,")
+    print("and then compares the numerical errors due to rounding and truncation.")
+    print()
     x = mpf(raw_input("Enter the value of x (e.g. 3.5): "))
     n = int(raw_input("Enter the number of terms n (e.g. 10): "))
-    print
+    print()
     exponential(x, n)

--- a/doc/source/plots/buildplots.py
+++ b/doc/source/plots/buildplots.py
@@ -1,10 +1,11 @@
+from __future__ import print_function
 import os.path
 import glob
 
 for f in glob.glob("*.py"):
     if "buildplots" in f or os.path.exists(f[:-3]+".png"):
         continue
-    print "Processing", f
+    print("Processing", f)
     code = open(f).readlines()
     code = ["from mpmath import *; mp.dps=5"] + code
     for i in range(len(code)):


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.  Discovered via #499 and fixed via

> futurize -f libfuturize.fixes.fix_print_with_import -w ./demo/manydigits.py ./demo/pidigits.py ./demo/plotting.py ./demo/taylor.py ./doc/source/plots/buildplots.py