### PR TITLE
Fix initialization of iv.matrix from non-interval matrix

### DIFF
--- a/mpmath/matrices/matrices.py
+++ b/mpmath/matrices/matrices.py
@@ -13,7 +13,7 @@ class _matrix(object):
     Elements default to zero.
     Use a flat list to create a column vector easily.
 
-    By default, only mpf is used to store the data. You can specify another type
+    By default, the datatype of the context (mpf for mp, mpi for iv, and float for fp)  is used to store the data. You can specify another type
     using force_type=type. It's possible to specify None.
     Make sure force_type(force_type()) is fast.
 
@@ -330,13 +330,12 @@ class _matrix(object):
                 self.__rows = args[0]
                 self.__cols = args[1]
         elif isinstance(args[0], _matrix):
-            A = args[0].copy()
-            self.__data = A._matrix__data
+            A = args[0]
             self.__rows = A._matrix__rows
             self.__cols = A._matrix__cols
             for i in xrange(A.__rows):
                 for j in xrange(A.__cols):
-                    A[i,j] = convert(A[i,j])
+                    self[i, j] = convert(A[i, j])
         elif hasattr(args[0], 'tolist'):
             A = self.ctx.matrix(args[0].tolist())
             self.__data = A._matrix__data
@@ -435,6 +434,7 @@ class _matrix(object):
                 1. Does not check on the value of key it expects key to be a integer tuple (i,j)
                 2. Does not check bounds
                 3. Does not check the value type
+                4. Does not reset the LU cache
         '''
         if value: # only store non-zeros
             self.__data[key] = value

--- a/mpmath/tests/test_matrices.py
+++ b/mpmath/tests/test_matrices.py
@@ -223,3 +223,31 @@ def test_interval_matrix_matrix_mult():
         assert X * M == X
         assert M * X == iv.matrix(X)
         assert M * X == X
+
+def test_matrix_conversion_to_iv():
+    # Test that matrices with foreign datatypes are properly converted
+    for other_type_eye in [eye(3), fp.eye(3), iv.eye(3)]:
+        A = iv.matrix(other_type_eye)
+        B = iv.eye(3)
+        assert type(A[0,0]) == type(B[0,0])
+        assert A.tolist() == B.tolist()
+
+def test_interval_matrix_mult_bug():
+    # regression test for interval matrix multiplication:
+    # result must be nonzero-width and contain the exact result
+    x = convert('1.00000000000001') # note: this is implicitly rounded to some near mpf float value
+    A = matrix([[x]])
+    B = iv.matrix(A)
+    C = iv.matrix([[x]])
+    assert B == C
+    B = B * B
+    C = C * C
+    assert B == C
+    assert B[0, 0].delta > 1e-16
+    assert B[0, 0].delta < 3e-16
+    assert C[0, 0].delta > 1e-16
+    assert C[0, 0].delta < 3e-16
+    assert mp.mpf('1.00000000000001998401444325291756783368705994138804689654') in B[0, 0]
+    assert mp.mpf('1.00000000000001998401444325291756783368705994138804689654') in C[0, 0]
+    # the following caused an error before the bug was fixed
+    assert iv.matrix(mp.eye(2)) * (iv.ones(2) + mpi(1, 2)) == iv.matrix([[mpi(2, 3), mpi(2, 3)], [mpi(2, 3), mpi(2, 3)]])


### PR DESCRIPTION
Non-interval datatypes were not converted to intervals, resulting in unexpected behavior. For example, `M[i, j]` from `mpmath.iv.matrix` didn't return `mpi` interval objects, but `mpf` floats, so `M[i, j] * M[k, l]` and, under certain conditions, `M * M`, was not performed as interval multiplication.

Before going into details, I'd like to ask a related question: How is the `force_type` argument supposed to work: Is this the expected result?
```
>>> M = mpmath.matrix(mpmath.matrix([[0,1,2]]), force_type=bool)
>>> M
matrix(
[['0.0', '1.0', '1.0']])
>>> type(M[0,0])
<class 'mpmath.ctx_mp_python.mpf'>
>>> M._matrix__data
{(0, 1): mpf('1.0'), (0, 2): mpf('1.0')}
```
The documentation states that the type is preserved, so I would expect `bool`, not `mpf`: (quote from the docs)
```
  If you want to preserve the type of the elements you can use
    ``force_type=None``:

        >>> matrix([[1, 2.5], [1j, mpf(2)]], force_type=None)
        matrix(
        [['1.0', '2.5'],
         [mpc(real='0.0', imag='1.0'), '2.0']])
```
However, even this documentation example shows that the type of matrix[0,0] is not preserved (int -> mpf), because setitem always calls ctx.convert(). In fact, the output doesn't change if `force_type=None` is omitted. The other doctest for `force_type` is skipped and would actually fail. (It seems these doctests were "disabled" in d29966edb887cc6246713ce78d6fa99f6eb16ff6 and were probably broken before).

I'd suggest removing `force_type` entirely because even if it worked, the resulting behavior could be rather unintuitive.


To come back to the original problem: The old behavior could have unexpected consequences, as outlined below.

"Exact" computation for reference:
```
>>> import mpmath
>>> x = mpmath.convert('1.00000000000001') # 1.0000...001 rounded to the next mpf floating point value
>>> mpmath.mp.dps=1000
>>> x*x # Good approximation of x*x
mpf('1.00000000000001998401444325291756783368705994138804689654360263219301518944348572404123842716217041015625')
```

Interval arithmetic should return an interval containing that value, with some uncertainty.

Restart python to reset mp.dps.
Before this commit, the following occurs:
```
>>> import mpmath
>>> x = mpmath.convert('1.00000000000001')
>>> x
mpf('1.00000000000001')
>>> A = mpmath.matrix([[x]])
>>> B = mpmath.iv.matrix(A)
>>> C = mpmath.iv.matrix([[x]])
>>> A*A
matrix(
[['1.00000000000002']])
>>> B*B
matrix(
[['[1.000000000000019984, 1.000000000000019984]']])
>>> (B*B)[0,0].delta
mpi('0.0', '0.0')
>>> C*C
matrix(
[['[1.000000000000019984, 1.0000000000000202061]']])
```

`B*B` is wrong, the interval width must be nonzero at the default precision of 15 digits.
`B*B != C*C`, although both were initialized from the same numerical value and computed the same way.

After this commit, the result is valid:
```
>>> B*B
matrix(
[['[1.000000000000019984, 1.0000000000000202061]']])
>>> (B*B)[0,0].delta
mpi('2.2204460492503131e-16', '2.2204460492503131e-16')
```
Some more insight:

Old incorrect behavior:
```
>>> mpmath.iv.matrix(mpmath.eye(1))[0,0]
mpf('1.0')
```

New correct behavior:
```
>>> mpmath.iv.matrix(mpmath.eye(1))
matrix(
[['[1.0, 1.0]']])
>>> mpmath.iv.matrix(mpmath.eye(1))[0,0]
mpi('1.0', '1.0')
>>> mpmath.fp.matrix(mpmath.eye(1))[0,0]
1.0
>>> mpmath.matrix(mpmath.eye(1))[0,0]
mpf('1.0')
```

The type now exactly matches the type returned by the context's matrix functions such as eye():
```
>>> mpmath.matrix(mpmath.eye(1))[0,0]
mpf('1.0')
>>> mpmath.eye(1)[0,0]
mpf('1.0')
>>> mpmath.iv.matrix(mpmath.eye(1))[0,0]
mpi('1.0', '1.0')
>>> mpmath.iv.eye(1)[0,0]
mpi('1.0', '1.0')
>>> mpmath.fp.matrix(mpmath.eye(1))[0,0]
1.0
>>> mpmath.fp.eye(1)[0,0]
1.0
```