### PR TITLE
Fix scalar-matrix-multiplication for mpi * iv.matrix

### DIFF
--- a/mpmath/ctx_iv.py
+++ b/mpmath/ctx_iv.py
@@ -19,6 +19,7 @@ from .libmp import (
     mpci_abs, mpci_pow, mpci_exp, mpci_log,
     ComplexResult,
     mpf_hash, mpc_hash)
+from .matrices.matrices import _matrix
 
 mpi_zero = (fzero, fzero)
 
@@ -251,6 +252,7 @@ def _binary_op(f_real, f_complex):
             tval = (tval, mpi_zero)
             return g_complex(ctx, sval, tval)
     def lop_real(s, t):
+        if isinstance(t, _matrix): return NotImplemented
         ctx = s.ctx
         if not isinstance(t, ctx._types): t = ctx.convert(t)
         if hasattr(t, "_mpi_"): return g_real(ctx, s._mpi_, t._mpi_)
@@ -263,6 +265,7 @@ def _binary_op(f_real, f_complex):
         if hasattr(t, "_mpci_"): return g_complex(ctx, t._mpci_, (s._mpi_, mpi_zero))
         return NotImplemented
     def lop_complex(s, t):
+        if isinstance(t, _matrix): return NotImplemented
         ctx = s.ctx
         if not isinstance(t, s.ctx._types):
             try:

--- a/mpmath/tests/test_matrices.py
+++ b/mpmath/tests/test_matrices.py
@@ -192,3 +192,30 @@ def test_matrix_numpy():
     l = [[1, 2], [3, 4], [5, 6]]
     a = numpy.array(l)
     assert matrix(l) == matrix(a)
+
+def test_interval_matrix_scalar_mult():
+    """Multiplication of iv.matrix and any scalar type"""
+    a = mpi(-1, 1)
+    b = a + a * 2j
+    c = mpf(42)
+    d = c + c * 2j
+    e = 1.234
+    f = fp.convert(e)
+    g = e + e * 3j
+    h = fp.convert(g)
+    M = iv.ones(1)
+    for x in [a, b, c, d, e, f, g, h]:
+        assert x * M == iv.matrix([x])
+        assert M * x == iv.matrix([x])
+
+@pytest.mark.xfail()
+def test_interval_matrix_matrix_mult():
+    """Multiplication of iv.matrix and other matrix types"""
+    A = ones(1)
+    B = fp.ones(1)
+    M = iv.ones(1)
+    for X in [A, B, M]:
+        assert X * M == iv.matrix(X)
+        assert X * M == X
+        assert M * X == iv.matrix(X)
+        assert M * X == X


### PR DESCRIPTION
Fixes this error:
```
>>> mpmath.mpi(1,2) * mpmath.iv.eye(1)
...
TypeError: cannot unpack non-iterable NoneType object
```

And adds a test for the currently failing case of `mpmath.mp.matrix * mpmath.iv.matrix`. That test is marked as expected failure.