### PR TITLE
Fix Travis CI build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 matrix:
+# When changing the supported python versions, please keep the README, .travis-ci.yml and setup.cfg in sync!
   include:
     - arch: arm64
       python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 matrix:
-# When changing the supported python versions, please keep the README, .travis-ci.yml and setup.cfg in sync!
   include:
     - arch: arm64
       python: 2.7
@@ -16,14 +15,8 @@ matrix:
       python: 3.8
     - arch: amd64
       python: pypy
-      before_install:
-        # Workaround for dependency errors, probably due to https://github.com/z4r/python-coveralls/issues/66
-      - pip install --upgrade --force-reinstall pytest-cov==2.5.0 
     - arch: amd64
       python: pypy3
-      before_install:
-        # Workaround for dependency errors, probably due to https://github.com/z4r/python-coveralls/issues/66
-        - pip install --upgrade --force-reinstall pytest-cov==2.5.0 
     - arch: arm64
       python: 2.7
       env: COVERAGE='on'
@@ -37,7 +30,8 @@ matrix:
       python: 3.6
       env: COVERAGE='on'
 install:
-  - pip install -U -e .[develop]
+  - pip install 'pip>=20.2.2'
+  - pip install --use-feature=2020-resolver -U -e .[develop]
 script:
   # Guard against invalid escapes in strings, like '\s'.
   - python -We:invalid -m compileall -f mpmath -q

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ matrix:
     - arch: amd64
       python: 2.7
     - arch: arm64
-      python: 3.5
-    - arch: amd64
-      python: 3.5
-    - arch: arm64
       python: 3.7
     - arch: amd64
       python: 3.7
@@ -19,8 +15,14 @@ matrix:
       python: 3.8
     - arch: amd64
       python: pypy
+      before_install:
+        # Workaround for dependency errors, probably due to https://github.com/z4r/python-coveralls/issues/66
+      - pip install --upgrade --force-reinstall pytest-cov==2.5.0 
     - arch: amd64
       python: pypy3
+      before_install:
+        # Workaround for dependency errors, probably due to https://github.com/z4r/python-coveralls/issues/66
+        - pip install --upgrade --force-reinstall pytest-cov==2.5.0 
     - arch: arm64
       python: 2.7
       env: COVERAGE='on'
@@ -33,14 +35,6 @@ matrix:
     - arch: amd64
       python: 3.6
       env: COVERAGE='on'
-    - arch: arm64
-      python: 3.4
-      before_install:
-        - pip install --upgrade --force-reinstall setuptools
-    - arch: amd64
-      python: 3.4
-      before_install:
-        - pip install --upgrade --force-reinstall setuptools
 install:
   - pip install -U -e .[develop]
 script:

--- a/README.rst
+++ b/README.rst
@@ -107,8 +107,8 @@ Release history:
 1. Download & installation
 --------------------------
 
-Mpmath requires Python 2.7 or 3.4 (or later versions). It has been tested
-with CPython 2.7, 3.4 through 3.7 and for PyPy.
+Mpmath requires Python 2.7 or 3.6 (or later versions). It has been tested
+with CPython 2.7, 3.6 through 3.7 and for PyPy.
 
 The latest release of mpmath can be downloaded from the mpmath
 website and from https://github.com/fredrik-johansson/mpmath/releases

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ author = Fredrik Johansson
 author_email = fredrik.johansson@gmail.com
 url = http://mpmath.org/
 license = BSD
+# When changing the supported python versions, please keep the README, .travis-ci.yml and setup.cfg in sync!
 classifiers = License :: OSI Approved :: BSD License
               Topic :: Scientific/Engineering :: Mathematics
               Topic :: Software Development :: Libraries :: Python Modules
@@ -13,8 +14,6 @@ classifiers = License :: OSI Approved :: BSD License
               Programming Language :: Python :: 2
               Programming Language :: Python :: 2.7
               Programming Language :: Python :: 3
-              Programming Language :: Python :: 3.4
-              Programming Language :: Python :: 3.5
               Programming Language :: Python :: 3.6
               Programming Language :: Python :: 3.7
               Programming Language :: Python :: Implementation :: CPython

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,6 @@ author = Fredrik Johansson
 author_email = fredrik.johansson@gmail.com
 url = http://mpmath.org/
 license = BSD
-# When changing the supported python versions, please keep the README, .travis-ci.yml and setup.cfg in sync!
 classifiers = License :: OSI Approved :: BSD License
               Topic :: Scientific/Engineering :: Mathematics
               Topic :: Software Development :: Libraries :: Python Modules


### PR DESCRIPTION
Travis CI for the current master branch gives errors for some Python versions:
```
pluggy.manager.PluginValidationError: Plugin 'pytest_cov' could not be loaded: (pytest 4.1.0 (/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages), Requirement.parse('pytest>=4.6'))!
```
https://travis-ci.org/github/MaxGaukler/mpmath/builds/727727144
The error may be due to https://github.com/z4r/python-coveralls/issues/66

Solution: drop CI support for Python 3.4 and 3.5, and apply a workaround for pypy. Note that Python 3.4 and 3.5 are EOL, so other projects like SymPy don't support them either (see [SymPy python version support policy](https://github.com/sympy/sympy/wiki/Python-version-support-policy))