### PR TITLE
Fix sys.version comparisons

### DIFF
--- a/mpmath/libmp/backend.py
+++ b/mpmath/libmp/backend.py
@@ -54,7 +54,7 @@ else:
     exec_ = getattr(builtins, "exec")
 
 # Define constants for calculating hash on Python 3.2.
-if sys.version >= "3.2":
+if sys.version_info >= (3, 2):
     HASH_MODULUS = sys.hash_info.modulus
     if sys.hash_info.width == 32:
         HASH_BITS = 31

--- a/mpmath/libmp/libmpc.py
+++ b/mpmath/libmp/libmpc.py
@@ -65,7 +65,7 @@ def mpc_to_complex(z, strict=False, rnd=round_fast):
     return complex(to_float(re, strict, rnd), to_float(im, strict, rnd))
 
 def mpc_hash(z):
-    if sys.version >= "3.2":
+    if sys.version_info >= (3, 2):
         re, im = z
         h = mpf_hash(re) + sys.hash_info.imag * mpf_hash(im)
         # Need to reduce either module 2^32 or 2^64

--- a/mpmath/libmp/libmpf.py
+++ b/mpmath/libmp/libmpf.py
@@ -544,7 +544,7 @@ def mpf_eq(s, t):
 
 def mpf_hash(s):
     # Duplicate the new hash algorithm introduces in Python 3.2.
-    if sys.version >= "3.2":
+    if sys.version_info >= (3, 2):
         ssign, sman, sexp, sbc = s
 
         # Handle special numbers

--- a/mpmath/rational.py
+++ b/mpmath/rational.py
@@ -52,7 +52,7 @@ class mpq(object):
 
     def __hash__(s):
         a, b = s._mpq_
-        if sys.version >= "3.2":
+        if sys.version_info >= (3, 2):
             inverse = pow(b, HASH_MODULUS-2, HASH_MODULUS)
             if not inverse:
                 h = sys.hash_info.inf

--- a/mpmath/tests/test_basic_ops.py
+++ b/mpmath/tests/test_basic_ops.py
@@ -147,7 +147,7 @@ def test_hash():
     assert hash(mp.mpq(1,1)) == hash(1)
     assert hash(mp.mpq(5,1)) == hash(5)
     assert hash(mp.mpq(1,2)) == hash(0.5)
-    if sys.version >= "3.2":
+    if sys.version_info >= (3, 2):
         assert hash(mpf(1)*2**2000) == hash(2**2000)
         assert hash(mpf(1)/2**2000) == hash(mpq(1,2**2000))
 


### PR DESCRIPTION
`sys.version >= "3.2"` will break in Python 3.10.