### PR TITLE
PrecisionManager preserves caller signature

### DIFF
--- a/mpmath/ctx_mp.py
+++ b/mpmath/ctx_mp.py
@@ -1322,8 +1322,6 @@ class PrecisionManager:
                     return f(*args, **kwargs)
             finally:
                 self.ctx.prec = orig
-        g.__name__ = f.__name__
-        g.__doc__ = f.__doc__
         return g
     def __enter__(self):
         self.origp = self.ctx.prec

--- a/mpmath/ctx_mp.py
+++ b/mpmath/ctx_mp.py
@@ -4,6 +4,8 @@ operating with them.
 """
 __docformat__ = 'plaintext'
 
+import functools
+
 import re
 
 from .ctx_base import StandardBaseContext
@@ -1303,6 +1305,7 @@ class PrecisionManager:
         self.dpsfun = dpsfun
         self.normalize_output = normalize_output
     def __call__(self, f):
+        @functools.wraps(f)
         def g(*args, **kwargs):
             orig = self.ctx.prec
             try:


### PR DESCRIPTION
This commit properly preserves the type annotations of the PrecisionManager caller.

Here's an example snippet:

```python
@workdps(3)
def test(arg1: int, arg2: str) -> None:
    """Preserve this docstring.

    :param arg1: Test
    :type arg1: int
    :param arg2: arg2
    :type arg2: str
    """
    return None
```

By properly wrapping the calling function, this  documentation could then be produced from probing the exports.

**BEFORE THE FIX**

![image](https://user-images.githubusercontent.com/26016342/102430169-98d3ef00-3fc7-11eb-9b1b-868f8fa2dd1f.png)



**AFTER THE FIX**

![image](https://user-images.githubusercontent.com/26016342/102429939-89ed3c80-3fc7-11eb-8bb5-f84c990fbbf9.png)


The type annotations were properly kept after the fix.