### PR TITLE
remove force_type arguments, they were broken

### DIFF
--- a/mpmath/calculus/optimization.py
+++ b/mpmath/calculus/optimization.py
@@ -598,7 +598,7 @@ def jacobian(ctx, f, x):
             J[i,j] = Jj[i]
     return J
 
-# TODO: test with user-specified jacobian matrix, support force_type
+# TODO: test with user-specified jacobian matrix
 class MDNewton:
     """
     Find the root of a vector function numerically using Newton's method.
@@ -693,14 +693,21 @@ str2solver = {'newton':Newton, 'secant':Secant, 'mnewton':MNewton,
 
 def findroot(ctx, f, x0, solver='secant', tol=None, verbose=False, verify=True, **kwargs):
     r"""
-    Find a solution to `f(x) = 0`, using *x0* as starting point or
+    Find an approximate solution to `f(x) = 0`, using *x0* as starting point or
     interval for *x*.
 
     Multidimensional overdetermined systems are supported.
     You can specify them using a function or a list of functions.
 
-    If the found root does not satisfy `|f(x)|^2 \leq \mathrm{tol}`,
-    an exception is raised (this can be disabled with *verify=False*).
+    Mathematically speaking, this function returns `x` such that
+    `|f(x)|^2 \leq \mathrm{tol}` is true within the current working precision.
+    If the computed value does not meet this criterion, an exception is raised.
+    This exception can be disabled with *verify=False*.
+
+    For interval arithmetic (``iv.findroot()``), please note that
+    the returned interval ``x`` is not guaranteed to contain `f(x)=0`!
+    It is only some `x` for which `|f(x)|^2 \leq \mathrm{tol}` certainly holds
+    regardless of numerical error. This may be improved in the future.
 
     **Arguments**
 

--- a/mpmath/matrices/linalg.py
+++ b/mpmath/matrices/linalg.py
@@ -37,10 +37,9 @@ inaccuracy of the internal floating point arithmetic. Though, it's even smaller
 than the current machine epsilon, which basically means you can trust the
 result.
 
-If you need more speed, use NumPy. Or choose a faster data type using the
-keyword ``force_type``::
+If you need more speed, use NumPy, or ``fp.lu_solve`` for a floating-point computation.
 
-    >>> lu_solve(A, b, force_type=float)
+    >>> fp.lu_solve(A, b)
     matrix(
     [['30.0'],
      ['-20.0']])
@@ -85,9 +84,9 @@ and equation solving with rigorous error bounds::
 
     >>> a = iv.matrix([['0.1','0.3','1.0'],
     ...             ['7.1','5.5','4.8'],
-    ...             ['3.2','4.4','5.6']], force_type=mpi)
+    ...             ['3.2','4.4','5.6']])
     >>>
-    >>> b = iv.matrix(['4','0.6','0.5'], force_type=mpi)
+    >>> b = iv.matrix(['4','0.6','0.5'])
     >>> c = iv.lu_solve(a, b)
     >>> print(c)
     [   [5.2582327113062568605927528666, 5.25823271130625686059275702219]]

--- a/mpmath/matrices/matrices.py
+++ b/mpmath/matrices/matrices.py
@@ -1,4 +1,5 @@
 from ..libmp.backend import xrange
+import warnings
 
 # TODO: interpret list as vectors (for multiplication)
 
@@ -13,9 +14,7 @@ class _matrix(object):
     Elements default to zero.
     Use a flat list to create a column vector easily.
 
-    By default, the datatype of the context (mpf for mp, mpi for iv, and float for fp)  is used to store the data. You can specify another type
-    using force_type=type. It's possible to specify None.
-    Make sure force_type(force_type()) is fast.
+    The datatype of the context (mpf for mp, mpi for iv, and float for fp) is used to store the data.
 
     Creating matrices
     -----------------
@@ -72,28 +71,12 @@ class _matrix(object):
         [['0.0', '0.0'],
          ['0.0', mpc(real='1.0', imag='1.0')]])
 
-    You can use the keyword ``force_type`` to change the function which is
-    called on every new element:
-
-        >>> matrix(2, 5, force_type=int) # doctest: +SKIP
-        matrix(
-        [[0, 0, 0, 0, 0],
-         [0, 0, 0, 0, 0]])
-
     A more comfortable way to create a matrix lets you use nested lists:
 
         >>> matrix([[1, 2], [3, 4]])
         matrix(
         [['1.0', '2.0'],
          ['3.0', '4.0']])
-
-    If you want to preserve the type of the elements you can use
-    ``force_type=None``:
-
-        >>> matrix([[1, 2.5], [1j, mpf(2)]], force_type=None)
-        matrix(
-        [['1.0', '2.5'],
-         [mpc(real='0.0', imag='1.0'), '2.0']])
 
     Convenient advanced functions are available for creating various standard
     matrices, see ``zeros``, ``ones``, ``diag``, ``eye``, ``randmatrix`` and
@@ -301,9 +284,12 @@ class _matrix(object):
         # multiple times, when calculating the inverse and when calculating the
         # determinant
         self._LU = None
-        convert = kwargs.get('force_type', self.ctx.convert)
-        if not convert:
-            convert = lambda x: x
+        if "force_type" in kwargs:
+            warnings.warn("The force_type argument was removed, it did not work"
+                " properly anyway. If you want to force floating-point or"
+                " interval computations, use the respective methods from `fp`"
+                " or `mp` instead, e.g., `fp.matrix()` or `iv.matrix()`."
+                " If you want to truncate values to integer, use .apply(int) instead.")
         if isinstance(args[0], (list, tuple)):
             if isinstance(args[0][0], (list, tuple)):
                 # interpret nested list as matrix
@@ -312,7 +298,8 @@ class _matrix(object):
                 self.__cols = len(A[0])
                 for i, row in enumerate(A):
                     for j, a in enumerate(row):
-                        self[i, j] = convert(a)
+                        # note: this will call __setitem__ which will call self.ctx.convert() to convert the datatype.
+                        self[i, j] = a
             else:
                 # interpret list as row vector
                 v = args[0]
@@ -335,7 +322,7 @@ class _matrix(object):
             self.__cols = A._matrix__cols
             for i in xrange(A.__rows):
                 for j in xrange(A.__cols):
-                    self[i, j] = convert(A[i, j])
+                    self[i, j] = A[i, j]
         elif hasattr(args[0], 'tolist'):
             A = self.ctx.matrix(args[0].tolist())
             self.__data = A._matrix__data

--- a/mpmath/tests/test_matrices.py
+++ b/mpmath/tests/test_matrices.py
@@ -23,7 +23,7 @@ def test_matrix_basic():
     A6 = matrix(l)
     assert A6.tolist() == l
     assert A6 == eval(repr(A6))
-    A6 = matrix(A6, force_type=float)
+    A6 = fp.matrix(A6)
     assert A6 == eval(repr(A6))
     assert A6*1j == eval(repr(A6*1j))
     assert A3 * 10 == 10 * A3 == A6

--- a/mpmath/tests/test_rootfinding.py
+++ b/mpmath/tests/test_rootfinding.py
@@ -23,9 +23,8 @@ def test_findroot():
     # test types
     f = lambda x: (x - 2)**2
 
-    #assert isinstance(findroot(f, 1, force_type=mpf, tol=1e-10), mpf)
-    #assert isinstance(findroot(f, 1., force_type=None, tol=1e-10), float)
-    #assert isinstance(findroot(f, 1, force_type=complex, tol=1e-10), complex)
+    assert isinstance(findroot(f, 1, tol=1e-10), mpf)
+    assert isinstance(iv.findroot(f, 1., tol=1e-10), iv.mpf)
     assert isinstance(fp.findroot(f, 1, tol=1e-10), float)
     assert isinstance(fp.findroot(f, 1+0j, tol=1e-10), complex)
 


### PR DESCRIPTION
Matrices should be type-stable, not allowing mixed types in one matrix. Always use the type of the context.
Therefore, specifying an element type by the "force_type" argument does not make sense.

It did not work properly before either, the data was not stored in the given type:
```
>>> M = mpmath.matrix(mpmath.matrix([[0,1,2]]), force_type=bool)
>>> M
matrix(
[['0.0', '1.0', '1.0']])
>>> type(M[0,0])
<class 'mpmath.ctx_mp_python.mpf'>
>>> M._matrix__data
{(0, 1): mpf('1.0'), (0, 2): mpf('1.0')}
```

Now the argument is removed and gives a warning instead:
```
>>> mpmath.matrix(mpmath.matrix([[0,1,2]]), force_type=bool)
/mpmath/mpmath/matrices/matrices.py:288: UserWarning: The force_type argument was removed, it did not work properly anyway. If you want to force floating-point or interval computations, use the respective methods from `fp` or `mp` instead, e.g., `fp.matrix()` or `iv.matrix()`. If you want to truncate values to integer, use .apply(int) instead.
  warnings.warn("The force_type argument was removed, it did not work"
matrix([['0.0', '1.0', '2.0']])
```