### PR TITLE
Get version from __init__

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ project_urls = Source = https://github.com/fredrik-johansson/mpmath
 [options]
 packages = find:
 setup_requires = setuptools>=36.7.0
-                 setuptools_scm>=1.7.0
 tests_require = mpmath[tests]
 [options.extras_require]
 tests = pytest >= 4.6

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,17 @@
 #!/usr/bin/env python
 
+import os
 import setuptools
 
+# where version is stored relative to setup.py
+_version_path = os.path.join(
+    os.path.dirname(__file__),
+    'mpmath/__init__.py')
+# get version without importing anything
+# note that this is relying on __version__
+# being the *first* line of the __init__ file
+with open(_version_path, 'r') as f:
+    # use eval to get a clean string of version from file
+    __version__ = eval(f.readline().strip().split('=')[-1])
 
-setuptools.setup(use_scm_version=True)
+setuptools.setup(version=__version__)


### PR DESCRIPTION
Attempt to fix #580. Gets version for setup from `__init__.py` to prevent duplication of version, and removes dependency on setuptools_scm. 

This is how many/most projects handle version; I'm not sure how mixing most data from `setup.cfg` with the version in `setup.py` works. Although in testing with `pip install -e` locally it worked fine. 