### PR TITLE
Pin setuptools_scm deps for python_version<"3.6"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,8 @@ project_urls = Source = https://github.com/fredrik-johansson/mpmath
 [options]
 packages = find:
 setup_requires = setuptools>=36.7.0
-                 setuptools_scm>=1.7.0
+                 setuptools_scm>=1.7.0,<6.0.0; python_version<"3.6"
+                 setuptools_scm>=3.2.0; python_version>="3.6"
 tests_require = mpmath[tests]
 [options.extras_require]
 tests = pytest >= 4.6


### PR DESCRIPTION
Closes #580

An alternative to #581.