### PR TITLE
prefer local sources over remote ones

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,4 @@
 import setuptools
 
 
-setuptools.setup(use_scm_version=True)
+setuptools.setup(use_scm_version=False)


### PR DESCRIPTION
While trying to upgrade SageMath's mpmath to 1.2.0, I had to patch this, see
https://trac.sagemath.org/ticket/31564#comment:9
(also, it simply does not work with new versions of setuptools etc)
```
[mpmath-1.2.0]     LookupError: setuptools-scm was unable to detect version for '/tmp/pip-req-build-i64_7gu6'.
[mpmath-1.2.0] 
[mpmath-1.2.0]     Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.
```
- probably due to missing meta-data.