### PR TITLE
Don't use setuptools_scm: revert to manual version management

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 name = mpmath
 description = Python library for arbitrary-precision floating-point arithmetic
 long_description = file: README.rst
+version = attr: mpmath.__version__
 author = Fredrik Johansson
 author_email = fredrik.johansson@gmail.com
 url = http://mpmath.org/
@@ -26,7 +27,6 @@ project_urls = Source = https://github.com/fredrik-johansson/mpmath
 [options]
 packages = find:
 setup_requires = setuptools>=36.7.0
-                 setuptools_scm>=1.7.0
 tests_require = mpmath[tests]
 [options.extras_require]
 tests = pytest >= 4.6

--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,4 @@
 import setuptools
 
 
-setuptools.setup(use_scm_version=True)
+setuptools.setup()


### PR DESCRIPTION
The setuptools_scm usage was broken by 867d8784 (likely,
this is a source of problem in #585)

Closes #580 (an alternative to #583 and #581)
Solves #585 as well.