### PR TITLE
Forbid gmpy2 for CPython 3.10 (fix build failure)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ develop = %(tests)s
           codecov
           wheel
 gmpy =
-    gmpy2>=2.1.0a4; platform_python_implementation!="PyPy"
+    gmpy2>=2.1.0a4; platform_python_implementation!="PyPy" and python_version < "3.10"
 docs = sphinx
 [pycodestyle]
 select = E101,W191,W291,W293,E111,E112,E113,W292,W391


### PR DESCRIPTION
Fix CI for the current master.