### PR TITLE
Fix CI failure for CPython 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install libs
       run: |
         sudo apt update
-        sudo apt install libmpc-dev latexmk texlive-xetex
+        sudo apt install latexmk texlive-xetex
     - name: Install dependencies
       run: |
         pip install --upgrade --force-reinstall setuptools pip
@@ -26,9 +26,6 @@ jobs:
         pycodestyle
     - name: Tests
       run: pytest
-    - name: Remove gmpy on 2.7
-      if: matrix.python-version == 2.7
-      run: pip uninstall -y gmpy2
     - name: Run coverage tests & upload results
       env:
         PYTEST_ADDOPTS: --cov mpmath

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
         pytest
         codecov --required
     - name: Building docs
+      if: matrix.python-version < 3.10
       run: |
         python setup.py build_sphinx -c docs -b html,latex
         make -C build/sphinx/latex all-pdf

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ develop = %(tests)s
           codecov
           wheel
 gmpy =
-    gmpy2>=2.1.0a4; platform_python_implementation!="PyPy"
+    gmpy2>=2.1.0a4; platform_python_implementation!="PyPy" and python_version>="3.6"
 docs = sphinx
 [pycodestyle]
 select = E101,W191,W291,W293,E111,E112,E113,W292,W391


### PR DESCRIPTION
* use wheels for gmpy2 (available for CPython > 3.5), an alternative to #601
* workaround for sphinx-doc