### PR TITLE
Support QR for matrices of width 0 and 1

### DIFF
--- a/mpmath/matrices/linalg.py
+++ b/mpmath/matrices/linalg.py
@@ -643,7 +643,7 @@ class LinearAlgebraMethods(object):
         assert isinstance(A, ctx.matrix)
         m = A.rows
         n = A.cols
-        assert n > 1
+        assert n >= 0
         assert m >= n
         assert edps >= 0
 

--- a/mpmath/tests/test_linalg.py
+++ b/mpmath/tests/test_linalg.py
@@ -275,8 +275,8 @@ def test_qr():
         flg = bool(k % 2)
 
         # generate arbitrary matrix size (2 to maxm)
-        num1 = nint(2 + (maxm-2)*rand())
-        num2 = nint(2 + (maxm-2)*rand())
+        num1 = nint(maxm*rand())
+        num2 = nint(maxm*rand())
         m = int(max(num1, num2))
         n = int(min(num1, num2))
 


### PR DESCRIPTION
Hi,

For some reason, the current QR code only permits matrices with 2 or more columns.

One column is a completely standard case and I see no reason why it shouldn't be supported.

I appreciate that 0 columns is a bit more of an edge case, it just returns an identity matrix for Q and an empty matrix for R. However, many LAPACK implementations support this, and it can be convenient not to have to special case this. (Right now I have to special case this at https://github.com/c-f-h/baryrat/blob/ad8c226b6ef3efdd04fc267baa34a6c4aa70e1fd/baryrat.py#L55, for instance).

It turns out that just by changing the check in the QR function to accept n>=0, both cases work completely as expected, and the tests run correctly when including these cases.