### PR TITLE
Faster numerical inverse Laplace transform

### DIFF
--- a/docs/calculus/inverselaplace.rst
+++ b/docs/calculus/inverselaplace.rst
@@ -27,6 +27,12 @@ de Hoog, Knight & Stokes algorithm
 .. autoclass:: mpmath.calculus.inverselaplace.deHoog
    :members:
 
+Cohen acceleration algorithm
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: mpmath.calculus.inverselaplace.Cohen
+   :members:   
+
 Manual approach 
 ...............
 
@@ -61,4 +67,5 @@ Credit
 ......
 
 The numerical inverse Laplace transform functionality was contributed
-to mpmath by Kristopher L. Kuhlman in 2017.
+to mpmath by Kristopher L. Kuhlman in 2017. The Cohen method was contributed
+to mpmath by Guillermo Navas-Palencia in 2022.

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -192,11 +192,13 @@ def test_invlap():
     assert invertlaplace(fp,t,method='talbot').ae(ftt)
     assert invertlaplace(fp,t,method='stehfest').ae(ftt)
     assert invertlaplace(fp,t,method='dehoog').ae(ftt)
+    assert invertlaplace(fp,t,method='cohen').ae(ftt)
     t = 1.0
     ftt = ft(t)
     assert invertlaplace(fp,t,method='talbot').ae(ftt)
     assert invertlaplace(fp,t,method='stehfest').ae(ftt)
     assert invertlaplace(fp,t,method='dehoog').ae(ftt)
+    assert invertlaplace(fp,t,method='cohen').ae(ftt)
 
     t = 0.01
     fp = lambda p: log(p)/p
@@ -205,8 +207,10 @@ def test_invlap():
     assert invertlaplace(fp,t,method='talbot').ae(ftt)
     assert invertlaplace(fp,t,method='stehfest').ae(ftt)
     assert invertlaplace(fp,t,method='dehoog').ae(ftt)
+    assert invertlaplace(fp,t,method='cohen').ae(ftt)
     t = 1.0
     ftt = ft(t)
     assert invertlaplace(fp,t,method='talbot').ae(ftt)
     assert invertlaplace(fp,t,method='stehfest').ae(ftt)
     assert invertlaplace(fp,t,method='dehoog').ae(ftt)
+    assert invertlaplace(fp,t,method='cohen').ae(ftt)


### PR DESCRIPTION
Faster numerical inverse Laplace transform by using a linear convergence acceleration method. The method is described in 
http://gnpalencia.org/blog/2022/invertlaplace/, including performance comparison against the three methods currently implemented.