### PR TITLE
Fix repr(mp.eps)

### DIFF
--- a/mpmath/ctx_mp_python.py
+++ b/mpmath/ctx_mp_python.py
@@ -353,7 +353,7 @@ class _constant(_mpf):
         return self.func(prec, rounding)
 
     def __repr__(self):
-        return "<%s: %s~>" % (self.name, self.context.nstr(self(dps=15)))
+        return "<%s: %s~>" % (self.name, self.context.nstr(self, n=6))
 
 
 class _mpc(mpnumeric):

--- a/mpmath/tests/test_convert.py
+++ b/mpmath/tests/test_convert.py
@@ -35,6 +35,12 @@ def test_basic_string():
     assert str(mpf("-2163048125L/1088391168")) == '-1.98738118113799'
     assert str(mpf("2163048125/1088391168l")) == '1.98738118113799'
 
+
+def test_eps_repr():
+    mp.dps = 24
+    assert repr(mp.eps) == '<epsilon of working precision: 2.06795e-25~>'
+
+
 def test_pretty():
     mp.pretty = True
     assert repr(mpf(2.5)) == '2.5'
@@ -45,6 +51,7 @@ def test_pretty():
     iv.pretty = False
 
 def test_str_whitespace():
+    mp.dps = 15
     assert mpf('1.26 ') == 1.26
 
 def test_unicode():


### PR DESCRIPTION
Before this change, repr(mp.eps) did not show the correct value
of eps.  The code was always converting the constant to dps=15, so
regardless of the setting of mp.dps, repr(mp.eps) would be

    '<epsilon of working precision: 2.22045e-16~>'

Closes gh-638.