### PR TITLE
Added Version 1.2.0 (February 2021) to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,7 @@ Credit also goes to:
 
 Release history:
 
+* Version 1.2.0 released on February 1, 2021
 * Version 1.1.0 released on December 11, 2018
 * Version 1.0.0 released on September 27, 2017
 * Version 0.19 released on June 10, 2014


### PR DESCRIPTION
1.2.0 (February 1, 2021) was already mentioned in the CHANGES file, but it seems that someone forgot to put it in the README.rst file that everyone sees on the GitHub main page. **I've fixed that here.**

I considered adding to CHANGES a description of the recent merging of #640 into Master:
> "Added square wave, triangle wave, sawtooth wave, and logistic sigmoid in signals.py and Sphinx documentation code in signals.txt"

But I figure that you would want to wait until 1.3.0 to add that.