### PR TITLE
Syntax Error: exec() is a function in Python 3

### DIFF
--- a/docs/plots/buildplots.py
+++ b/docs/plots/buildplots.py
@@ -20,4 +20,4 @@ for f in glob.glob("*.py"):
             l = l[:-1] + (", dpi=45, file='%s.png')" % f[:-3])
             code[i] = l
     code = "\n".join(code)
-    exec code
+    exec(code)


### PR DESCRIPTION
This syntax works in both Python 2 and Python 3.
* https://portingguide.readthedocs.io/en/latest/builtins.html#exec
* https://docs.python.org/2/reference/simple_stmts.html#exec
* https://docs.python.org/3/library/functions.html#exec